### PR TITLE
Medical Certificate: Print View & PDF (Landscape) with Dynamic Patient Data + Layout & Styling Fixes

### DIFF
--- a/app/Http/Controllers/MedicalCertificateController.php
+++ b/app/Http/Controllers/MedicalCertificateController.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MedicalCertificate;
+use App\Models\Patient;
+use Illuminate\Http\Request;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Carbon\Carbon;
+
+class MedicalCertificateController extends Controller
+{
+    /**
+     * Get all medical certificates for a patient
+     *
+     * @param int $patientId
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getByPatient($patientId)
+    {
+        $certificates = MedicalCertificate::where('patient_id', $patientId)
+            ->orderByDesc('date_issued')
+            ->get();
+
+        return response()->json(['certificates' => $certificates]);
+    }
+
+    /**
+     * Store a newly created medical certificate
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'patient_id' => 'required|exists:patients,id',
+            'certificate_type' => 'required|string|in:fitness_work,medical_leave,travel_clearance,school_sports,custom',
+            'purpose' => 'required|string|max:255',
+            'date_issued' => 'required|date',
+            'valid_until' => 'nullable|date|after:date_issued',
+            'issuing_doctor' => 'required|string|max:255',
+            'license_number' => 'nullable|string|max:255',
+            'medical_findings' => 'nullable|string',
+            'recommendations' => 'nullable|string',
+            'digital_signature' => 'boolean'
+        ]);
+
+        $certificate = MedicalCertificate::create($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Medical certificate issued successfully',
+            'certificate' => $certificate
+        ]);
+    }
+
+    /**
+     * Display the specified medical certificate
+     *
+     * @param int $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show($id)
+    {
+        $certificate = MedicalCertificate::with('patient')->findOrFail($id);
+
+        return response()->json(['certificate' => $certificate]);
+    }
+
+    /**
+     * Generate and download PDF of the medical certificate
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function downloadPdf($id)
+    {
+        $certificate = MedicalCertificate::with('patient')->findOrFail($id);
+
+        $pdf = Pdf::loadView('patients.management.components.medical_certificate.print', compact('certificate'))
+            ->setPaper('a4', 'portrait');
+
+        return $pdf->download("medical_certificate_{$certificate->id}.pdf");
+    }
+
+    /**
+     * View PDF of the medical certificate in browser
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function viewPdf($id)
+    {
+        $certificate = MedicalCertificate::with('patient')->findOrFail($id);
+
+        $pdf = Pdf::loadView('patients.management.components.medical_certificate.print', compact('certificate'))
+            ->setPaper('a4', 'portrait');
+
+        return $pdf->stream("medical_certificate_{$certificate->id}.pdf");
+    }
+
+    /**
+     * Revoke a medical certificate
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param int $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function revoke(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'revocation_reason' => 'required|string|max:500'
+        ]);
+
+        $certificate = MedicalCertificate::findOrFail($id);
+
+        $certificate->update([
+            'status' => 'revoked',
+            'revocation_reason' => $validated['revocation_reason'],
+            'revoked_at' => Carbon::now()
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Medical certificate revoked successfully'
+        ]);
+    }
+
+    /**
+     * Update the specified medical certificate
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param int $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request, $id)
+    {
+        $certificate = MedicalCertificate::findOrFail($id);
+
+        $validated = $request->validate([
+            'certificate_type' => 'required|string|in:fitness_work,medical_leave,travel_clearance,school_sports,custom',
+            'purpose' => 'required|string|max:255',
+            'valid_until' => 'nullable|date|after:date_issued',
+            'issuing_doctor' => 'required|string|max:255',
+            'license_number' => 'nullable|string|max:255',
+            'medical_findings' => 'nullable|string',
+            'recommendations' => 'nullable|string',
+        ]);
+
+        $certificate->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Medical certificate updated successfully',
+            'certificate' => $certificate
+        ]);
+    }
+}

--- a/app/Http/Controllers/MedicalCertificateController.php
+++ b/app/Http/Controllers/MedicalCertificateController.php
@@ -96,7 +96,7 @@ class MedicalCertificateController extends Controller
         $certificate = MedicalCertificate::with('patient')->findOrFail($id);
         $patient = $certificate->patient;
 
-        $pdf = Pdf::loadView('patients.management.components.medical_certificate_pdf', compact('certificate', 'patient'))
+        $pdf = Pdf::loadView('patients.management.components.medical_certificate_download_pdf', compact('certificate', 'patient'))
             ->setPaper([0, 0, 612, 396], 'landscape'); // 8.5in x 5.5in in points (72 points per inch)
 
         return $pdf->stream("medical_certificate_{$certificate->id}.pdf");

--- a/app/Http/Controllers/MedicalCertificateController.php
+++ b/app/Http/Controllers/MedicalCertificateController.php
@@ -77,9 +77,10 @@ class MedicalCertificateController extends Controller
     public function downloadPdf($id)
     {
         $certificate = MedicalCertificate::with('patient')->findOrFail($id);
+        $patient = $certificate->patient;
 
-        $pdf = Pdf::loadView('patients.management.components.medical_certificate.print', compact('certificate'))
-            ->setPaper('a4', 'portrait');
+        $pdf = Pdf::loadView('patients.management.components.medical_certificate_download_pdf', compact('certificate', 'patient'))
+            ->setPaper([0, 0, 612, 396], 'landscape'); // 8.5in x 5.5in in points (72 points per inch)
 
         return $pdf->download("medical_certificate_{$certificate->id}.pdf");
     }
@@ -93,9 +94,10 @@ class MedicalCertificateController extends Controller
     public function viewPdf($id)
     {
         $certificate = MedicalCertificate::with('patient')->findOrFail($id);
+        $patient = $certificate->patient;
 
-        $pdf = Pdf::loadView('patients.management.components.medical_certificate.print', compact('certificate'))
-            ->setPaper('a4', 'portrait');
+        $pdf = Pdf::loadView('patients.management.components.medical_certificate_pdf', compact('certificate', 'patient'))
+            ->setPaper([0, 0, 612, 396], 'landscape'); // 8.5in x 5.5in in points (72 points per inch)
 
         return $pdf->stream("medical_certificate_{$certificate->id}.pdf");
     }

--- a/app/Http/Controllers/ReferralFormController.php
+++ b/app/Http/Controllers/ReferralFormController.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ReferralForm;
+use App\Models\Patient;
+use Illuminate\Http\Request;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Carbon\Carbon;
+
+class ReferralFormController extends Controller
+{
+    /**
+     * Get all referral forms for a patient
+     *
+     * @param int $patientId
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getByPatient($patientId)
+    {
+        $referrals = ReferralForm::where('patient_id', $patientId)
+            ->orderByDesc('referral_date')
+            ->get();
+
+        return response()->json(['referrals' => $referrals]);
+    }
+
+    /**
+     * Store a newly created referral form
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'patient_id' => 'required|exists:patients,id',
+            'referral_date' => 'required|date',
+            'priority' => 'required|string|in:routine,urgent,emergency',
+            'specialty' => 'required|string|max:255',
+            'referred_doctor' => 'required|string|max:255',
+            'institution' => 'nullable|string|max:255',
+            'contact_info' => 'nullable|string|max:255',
+            'reason_for_referral' => 'required|string',
+            'relevant_history' => 'nullable|string',
+            'urgency_reason' => 'nullable|string',
+            'include_reports' => 'boolean',
+            'referring_doctor' => 'nullable|string|max:255'
+        ]);
+
+        $referral = ReferralForm::create($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Referral form created successfully',
+            'referral' => $referral
+        ]);
+    }
+
+    /**
+     * Display the specified referral form
+     *
+     * @param int $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show($id)
+    {
+        $referral = ReferralForm::with('patient')->findOrFail($id);
+
+        return response()->json(['referral' => $referral]);
+    }
+
+    /**
+     * Generate and print PDF of the referral form
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function printPdf($id)
+    {
+        $referral = ReferralForm::with('patient')->findOrFail($id);
+
+        $pdf = Pdf::loadView('patients.management.components.referral_form.print', compact('referral'))
+            ->setPaper('a4', 'portrait');
+
+        return $pdf->stream("referral_form_{$referral->id}.pdf");
+    }
+
+    /**
+     * Download PDF of the referral form
+     *
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function downloadPdf($id)
+    {
+        $referral = ReferralForm::with('patient')->findOrFail($id);
+
+        $pdf = Pdf::loadView('patients.management.components.referral_form.print', compact('referral'))
+            ->setPaper('a4', 'portrait');
+
+        return $pdf->download("referral_form_{$referral->id}.pdf");
+    }
+
+    /**
+     * Update tracking information for referral
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param int $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateTracking(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'status' => 'required|string|in:pending,in_progress,completed,cancelled',
+            'tracking_notes' => 'nullable|string',
+            'appointment_date' => 'nullable|date',
+            'outcome' => 'nullable|string'
+        ]);
+
+        $referral = ReferralForm::findOrFail($id);
+        $referral->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Tracking information updated successfully',
+            'referral' => $referral
+        ]);
+    }
+
+    /**
+     * Update the specified referral form
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param int $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request, $id)
+    {
+        $referral = ReferralForm::findOrFail($id);
+
+        $validated = $request->validate([
+            'priority' => 'required|string|in:routine,urgent,emergency',
+            'specialty' => 'required|string|max:255',
+            'referred_doctor' => 'required|string|max:255',
+            'institution' => 'nullable|string|max:255',
+            'contact_info' => 'nullable|string|max:255',
+            'reason_for_referral' => 'required|string',
+            'relevant_history' => 'nullable|string',
+            'urgency_reason' => 'nullable|string',
+            'referring_doctor' => 'nullable|string|max:255'
+        ]);
+
+        $referral->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Referral form updated successfully',
+            'referral' => $referral
+        ]);
+    }
+
+    /**
+     * Get referral statistics for a patient
+     *
+     * @param int $patientId
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getStatistics($patientId)
+    {
+        $stats = [
+            'pending' => ReferralForm::where('patient_id', $patientId)->where('status', 'pending')->count(),
+            'in_progress' => ReferralForm::where('patient_id', $patientId)->where('status', 'in_progress')->count(),
+            'completed' => ReferralForm::where('patient_id', $patientId)->where('status', 'completed')->count(),
+            'cancelled' => ReferralForm::where('patient_id', $patientId)->where('status', 'cancelled')->count(),
+            'total' => ReferralForm::where('patient_id', $patientId)->count()
+        ];
+
+        $specialties = ReferralForm::where('patient_id', $patientId)
+            ->selectRaw('specialty, count(*) as count')
+            ->groupBy('specialty')
+            ->orderByDesc('count')
+            ->get();
+
+        return response()->json([
+            'statistics' => $stats,
+            'specialties' => $specialties
+        ]);
+    }
+}

--- a/app/Models/MedicalCertificate.php
+++ b/app/Models/MedicalCertificate.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MedicalCertificate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'patient_id',
+        'date_issued',
+        'certificate_type',
+        'purpose',
+        'valid_until',
+        'issuing_doctor',
+        'license_number',
+        'medical_findings',
+        'recommendations',
+        'digital_signature',
+        'status',
+        'revocation_reason',
+        'revoked_at'
+    ];
+
+    protected $casts = [
+        'date_issued' => 'date',
+        'valid_until' => 'date',
+        'digital_signature' => 'boolean',
+        'revoked_at' => 'datetime'
+    ];
+
+    // Define relationships
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    // Scope for active certificates
+    public function scopeActive($query)
+    {
+        return $query->where('status', 'active');
+    }
+
+    // Check if certificate is expired
+    public function getIsExpiredAttribute()
+    {
+        return $this->valid_until && $this->valid_until->isPast();
+    }
+
+    // Get status badge color
+    public function getStatusBadgeAttribute()
+    {
+        return match ($this->status) {
+            'active' => 'bg-success',
+            'revoked' => 'bg-danger',
+            'expired' => 'bg-secondary',
+            default => 'bg-secondary'
+        };
+    }
+
+    // Get certificate type display name
+    public function getCertificateTypeDisplayAttribute()
+    {
+        return match ($this->certificate_type) {
+            'fitness_work' => 'Fitness for Work',
+            'medical_leave' => 'Medical Leave',
+            'travel_clearance' => 'Travel Clearance',
+            'school_sports' => 'School/Sports',
+            'custom' => 'Custom Certificate',
+            default => ucfirst(str_replace('_', ' ', $this->certificate_type))
+        };
+    }
+}

--- a/app/Models/ReferralForm.php
+++ b/app/Models/ReferralForm.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ReferralForm extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'patient_id',
+        'referral_date',
+        'priority',
+        'specialty',
+        'referred_doctor',
+        'institution',
+        'contact_info',
+        'reason_for_referral',
+        'relevant_history',
+        'urgency_reason',
+        'include_reports',
+        'status',
+        'tracking_notes',
+        'appointment_date',
+        'outcome',
+        'referring_doctor'
+    ];
+
+    protected $casts = [
+        'referral_date' => 'date',
+        'appointment_date' => 'date',
+        'include_reports' => 'boolean'
+    ];
+
+    // Define relationships
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    // Scope for pending referrals
+    public function scopePending($query)
+    {
+        return $query->where('status', 'pending');
+    }
+
+    // Scope for completed referrals
+    public function scopeCompleted($query)
+    {
+        return $query->where('status', 'completed');
+    }
+
+    // Get priority badge color
+    public function getPriorityBadgeAttribute()
+    {
+        return match ($this->priority) {
+            'routine' => 'bg-warning',
+            'urgent' => 'bg-danger',
+            'emergency' => 'bg-dark',
+            default => 'bg-secondary'
+        };
+    }
+
+    // Get status badge color
+    public function getStatusBadgeAttribute()
+    {
+        return match ($this->status) {
+            'pending' => 'bg-warning',
+            'in_progress' => 'bg-info',
+            'completed' => 'bg-success',
+            'cancelled' => 'bg-danger',
+            default => 'bg-secondary'
+        };
+    }
+
+    // Get priority display name
+    public function getPriorityDisplayAttribute()
+    {
+        return ucfirst($this->priority);
+    }
+
+    // Get status display name
+    public function getStatusDisplayAttribute()
+    {
+        return match ($this->status) {
+            'in_progress' => 'In Progress',
+            default => ucfirst($this->status)
+        };
+    }
+
+    // Get specialty display name
+    public function getSpecialtyDisplayAttribute()
+    {
+        return ucfirst($this->specialty);
+    }
+}

--- a/database/migrations/2025_10_02_000000_create_medical_certificates_table.php
+++ b/database/migrations/2025_10_02_000000_create_medical_certificates_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('medical_certificates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('patient_id')->constrained('patients')->onDelete('cascade');
+            $table->date('date_issued');
+            $table->string('certificate_type'); // fitness_work, medical_leave, travel_clearance, school_sports, custom
+            $table->string('purpose');
+            $table->date('valid_until')->nullable();
+            $table->string('issuing_doctor');
+            $table->string('license_number')->nullable();
+            $table->text('medical_findings')->nullable();
+            $table->text('recommendations')->nullable();
+            $table->boolean('digital_signature')->default(false);
+            $table->enum('status', ['active', 'revoked', 'expired'])->default('active');
+            $table->text('revocation_reason')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('medical_certificates');
+    }
+};

--- a/database/migrations/2025_10_02_000001_create_referral_forms_table.php
+++ b/database/migrations/2025_10_02_000001_create_referral_forms_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('referral_forms', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('patient_id')->constrained('patients')->onDelete('cascade');
+            $table->date('referral_date');
+            $table->enum('priority', ['routine', 'urgent', 'emergency'])->default('routine');
+            $table->string('specialty');
+            $table->string('referred_doctor');
+            $table->string('institution')->nullable();
+            $table->string('contact_info')->nullable();
+            $table->text('reason_for_referral');
+            $table->text('relevant_history')->nullable();
+            $table->text('urgency_reason')->nullable();
+            $table->boolean('include_reports')->default(false);
+            $table->enum('status', ['pending', 'completed', 'cancelled', 'in_progress'])->default('pending');
+            $table->text('tracking_notes')->nullable();
+            $table->date('appointment_date')->nullable();
+            $table->text('outcome')->nullable();
+            $table->string('referring_doctor')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('referral_forms');
+    }
+};

--- a/resources/views/patients/management/components/medical_certificate.blade.php
+++ b/resources/views/patients/management/components/medical_certificate.blade.php
@@ -60,9 +60,7 @@
         <div class="certificate-header">
             <div class="logo-section">
                 <div class="medical-logo">
-                    <div class="logo-circle">
-                        <i class="fas fa-cross"></i>
-                    </div>
+                    <img src="{{ asset('images/dmsf_logo_transparent.png') }}" alt="DMSF Logo">
                 </div>
             </div>
             <div class="institution-info">
@@ -174,11 +172,12 @@
 <style>
     .medical-certificate-container {
         max-width: 8.5in;
-        margin: 0 auto;
+        margin: 0 auto 3rem auto;
         background: white;
         font-family: 'Times New Roman', serif;
         color: #000;
         line-height: 1.2;
+        padding-bottom: 2rem;
     }
 
     .certificate-page {
@@ -199,19 +198,21 @@
     }
 
     .logo-section {
-        flex: 0 0 80px;
+        flex: 0 0 100px;
         margin-right: 15px;
     }
 
-    .medical-logo .logo-circle {
-        width: 60px;
-        height: 60px;
-        border: 2px solid #000;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 18px;
+    .medical-logo {
+        width: 100px;
+        height: 100px;
+        margin-left: 20px;
+        margin-bottom: 20px;
+    }
+
+    .medical-logo img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
     }
 
     .institution-info {
@@ -411,9 +412,10 @@
 
     /* Print controls positioning */
     .print-controls {
-        margin-top: 3rem;
-        padding: 2rem 0;
+        margin-top: 8rem !important;
+        padding: 3rem 0;
         border-top: 1px solid #dee2e6;
+        clear: both;
     }
 
     /* Print Styles */

--- a/resources/views/patients/management/components/medical_certificate.blade.php
+++ b/resources/views/patients/management/components/medical_certificate.blade.php
@@ -15,9 +15,9 @@
                     </button>
                 </div>
             </div>
-            
+
             <div class="table-responsive">
-                <table class="table table-striped table-hover">
+                <table class="table table-striped table-hover" id="medical-certificates-table">
                     <thead class="table-dark">
                         <tr>
                             <th>Date Issued</th>
@@ -28,28 +28,12 @@
                             <th>Actions</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <tr>
-                            <td>{{ date('Y-m-d') }}</td>
-                            <td>Fitness for Work</td>
-                            <td>Return to work clearance</td>
-                            <td>{{ date('Y-m-d', strtotime('+30 days')) }}</td>
-                            <td><span class="badge bg-success">Active</span></td>
-                            <td>
-                                <button class="btn btn-sm btn-outline-primary">View PDF</button>
-                                <button class="btn btn-sm btn-outline-success">Download</button>
-                                <button class="btn btn-sm btn-outline-warning">Revoke</button>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="6" class="text-center text-muted">
-                                <em>No additional medical certificates found. Click "Issue Medical Certificate" to get started.</em>
-                            </td>
-                        </tr>
+                    <tbody id="certificates-tbody">
+                        <!-- Dynamic content will be loaded here -->
                     </tbody>
                 </table>
             </div>
-            
+
             <div class="row mt-4">
                 <div class="col-md-12">
                     <div class="alert alert-info">
@@ -77,11 +61,13 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <form>
+                <form id="medical-certificate-form">
+                    @csrf
+                    <input type="hidden" name="patient_id" value="{{ $patient->id }}">
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="certificateType" class="form-label">Certificate Type</label>
-                            <select class="form-select" id="certificateType">
+                            <select class="form-select" id="certificateType" name="certificate_type" required>
                                 <option value="">Select certificate type</option>
                                 <option value="fitness_work">Fitness for Work</option>
                                 <option value="medical_leave">Medical Leave</option>
@@ -92,39 +78,39 @@
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="purpose" class="form-label">Purpose</label>
-                            <input type="text" class="form-control" id="purpose" placeholder="e.g., Return to work after illness">
+                            <input type="text" class="form-control" id="purpose" name="purpose" placeholder="e.g., Return to work after illness" required>
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="issueDate" class="form-label">Issue Date</label>
-                            <input type="date" class="form-control" id="issueDate" value="{{ date('Y-m-d') }}">
+                            <input type="date" class="form-control" id="issueDate" name="date_issued" value="{{ date('Y-m-d') }}" required>
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="validUntil" class="form-label">Valid Until</label>
-                            <input type="date" class="form-control" id="validUntil">
+                            <input type="date" class="form-control" id="validUntil" name="valid_until">
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="issuingDoctor" class="form-label">Issuing Doctor</label>
-                            <input type="text" class="form-control" id="issuingDoctor" placeholder="Dr. Name">
+                            <input type="text" class="form-control" id="issuingDoctor" name="issuing_doctor" placeholder="Dr. Name" required>
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="licenseNumber" class="form-label">License Number</label>
-                            <input type="text" class="form-control" id="licenseNumber" placeholder="Medical license number">
+                            <input type="text" class="form-control" id="licenseNumber" name="license_number" placeholder="Medical license number">
                         </div>
                     </div>
                     <div class="mb-3">
                         <label for="medicalFindings" class="form-label">Medical Findings</label>
-                        <textarea class="form-control" id="medicalFindings" rows="3" placeholder="Brief medical assessment and findings"></textarea>
+                        <textarea class="form-control" id="medicalFindings" name="medical_findings" rows="3" placeholder="Brief medical assessment and findings"></textarea>
                     </div>
                     <div class="mb-3">
                         <label for="recommendations" class="form-label">Recommendations/Restrictions</label>
-                        <textarea class="form-control" id="recommendations" rows="3" placeholder="Any work restrictions or recommendations"></textarea>
+                        <textarea class="form-control" id="recommendations" name="recommendations" rows="3" placeholder="Any work restrictions or recommendations"></textarea>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="digitalSignature">
+                        <input class="form-check-input" type="checkbox" id="digitalSignature" name="digital_signature" value="1">
                         <label class="form-check-label" for="digitalSignature">
                             Apply digital signature
                         </label>
@@ -133,9 +119,228 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-outline-primary">Preview</button>
-                <button type="button" class="btn btn-primary">Issue Certificate</button>
+                <button type="button" class="btn btn-outline-primary" id="preview-certificate-btn">Preview</button>
+                <button type="button" class="btn btn-primary" id="issue-certificate-btn">Issue Certificate</button>
             </div>
         </div>
     </div>
-</div> 
+</div>
+
+<!-- Revoke Certificate Modal -->
+<div class="modal fade" id="revokeCertificateModal" tabindex="-1" aria-labelledby="revokeCertificateModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="revokeCertificateModalLabel">Revoke Medical Certificate</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="revoke-certificate-form">
+                    @csrf
+                    <input type="hidden" id="revoke-certificate-id" name="certificate_id">
+                    <div class="mb-3">
+                        <label for="revocationReason" class="form-label">Reason for Revocation</label>
+                        <textarea class="form-control" id="revocationReason" name="revocation_reason" rows="3" placeholder="Please provide reason for revoking this certificate" required></textarea>
+                    </div>
+                    <div class="alert alert-warning">
+                        <strong>Warning:</strong> This action cannot be undone. The certificate will be permanently marked as revoked.
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirm-revoke-btn">Revoke Certificate</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function() {
+        // Load certificates on page load
+        loadMedicalCertificates();
+
+        // Issue certificate form submission
+        $('#issue-certificate-btn').click(function() {
+            const form = $('#medical-certificate-form')[0];
+            const formData = new FormData(form);
+
+            $.ajax({
+                url: "{{ route('medical-certificates.store') }}",
+                method: "POST",
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: function(response) {
+                    if (response.success) {
+                        alert("Medical certificate issued successfully!");
+                        $('#addCertificateModal').modal('hide');
+                        $('#medical-certificate-form')[0].reset();
+                        loadMedicalCertificates();
+                    }
+                },
+                error: function(xhr) {
+                    let errorMessage = "An error occurred. Please try again.";
+                    if (xhr.responseJSON && xhr.responseJSON.errors) {
+                        const errors = xhr.responseJSON.errors;
+                        errorMessage = Object.values(errors).flat().join('\n');
+                    }
+                    alert(errorMessage);
+                }
+            });
+        });
+
+        // Load medical certificates
+        function loadMedicalCertificates() {
+            $.ajax({
+                url: "{{ route('patients.medical-certificates', $patient->id) }}",
+                method: "GET",
+                success: function(response) {
+                    const tbody = $('#certificates-tbody');
+                    tbody.empty();
+
+                    if (response.certificates.length === 0) {
+                        tbody.append(`
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">
+                                <em>No medical certificates found. Click "Issue Medical Certificate" to get started.</em>
+                            </td>
+                        </tr>
+                    `);
+                    } else {
+                        response.certificates.forEach(function(cert) {
+                            const statusBadge = getStatusBadge(cert.status);
+                            const actions = getActionButtons(cert);
+
+                            tbody.append(`
+                            <tr>
+                                <td>${formatDate(cert.date_issued)}</td>
+                                <td>${getCertificateTypeDisplay(cert.certificate_type)}</td>
+                                <td>${cert.purpose}</td>
+                                <td>${cert.valid_until ? formatDate(cert.valid_until) : 'No expiry'}</td>
+                                <td><span class="badge ${statusBadge}">${cert.status.charAt(0).toUpperCase() + cert.status.slice(1)}</span></td>
+                                <td>${actions}</td>
+                            </tr>
+                        `);
+                        });
+                    }
+                },
+                error: function(xhr) {
+                    console.error("Error loading medical certificates:", xhr);
+                    alert("Error loading medical certificates. Please refresh the page.");
+                }
+            });
+        }
+
+        // Get status badge class
+        function getStatusBadge(status) {
+            switch (status) {
+                case 'active':
+                    return 'bg-success';
+                case 'revoked':
+                    return 'bg-danger';
+                case 'expired':
+                    return 'bg-secondary';
+                default:
+                    return 'bg-secondary';
+            }
+        }
+
+        // Get certificate type display name
+        function getCertificateTypeDisplay(type) {
+            switch (type) {
+                case 'fitness_work':
+                    return 'Fitness for Work';
+                case 'medical_leave':
+                    return 'Medical Leave';
+                case 'travel_clearance':
+                    return 'Travel Clearance';
+                case 'school_sports':
+                    return 'School/Sports';
+                case 'custom':
+                    return 'Custom Certificate';
+                default:
+                    return type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
+            }
+        }
+
+        // Get action buttons
+        function getActionButtons(cert) {
+            let buttons = `
+            <button class="btn btn-sm btn-outline-primary view-pdf-btn" data-id="${cert.id}">View PDF</button>
+            <button class="btn btn-sm btn-outline-success download-pdf-btn" data-id="${cert.id}">Download</button>
+        `;
+
+            if (cert.status === 'active') {
+                buttons += `<button class="btn btn-sm btn-outline-warning revoke-btn" data-id="${cert.id}">Revoke</button>`;
+            }
+
+            return buttons;
+        }
+
+        // Format date
+        function formatDate(dateString) {
+            const date = new Date(dateString);
+            return date.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+            });
+        }
+
+        // View PDF button click
+        $(document).on('click', '.view-pdf-btn', function() {
+            const certId = $(this).data('id');
+            window.open(`{{ url('/medical-certificates') }}/${certId}/pdf`, '_blank');
+        });
+
+        // Download PDF button click
+        $(document).on('click', '.download-pdf-btn', function() {
+            const certId = $(this).data('id');
+            window.location.href = `{{ url('/medical-certificates') }}/${certId}/download`;
+        });
+
+        // Revoke button click
+        $(document).on('click', '.revoke-btn', function() {
+            const certId = $(this).data('id');
+            $('#revoke-certificate-id').val(certId);
+            $('#revokeCertificateModal').modal('show');
+        });
+
+        // Confirm revoke button click
+        $('#confirm-revoke-btn').click(function() {
+            const certId = $('#revoke-certificate-id').val();
+            const reason = $('#revocationReason').val();
+
+            if (!reason.trim()) {
+                alert("Please provide a reason for revocation.");
+                return;
+            }
+
+            $.ajax({
+                url: `{{ url('/medical-certificates') }}/${certId}/revoke`,
+                method: "PUT",
+                data: {
+                    _token: "{{ csrf_token() }}",
+                    revocation_reason: reason
+                },
+                success: function(response) {
+                    if (response.success) {
+                        alert("Medical certificate revoked successfully!");
+                        $('#revokeCertificateModal').modal('hide');
+                        $('#revoke-certificate-form')[0].reset();
+                        loadMedicalCertificates();
+                    }
+                },
+                error: function(xhr) {
+                    alert("An error occurred while revoking the certificate. Please try again.");
+                }
+            });
+        });
+
+        // Preview certificate functionality
+        $('#preview-certificate-btn').click(function() {
+            alert("Preview functionality will be implemented in future updates.");
+        });
+    });
+</script>

--- a/resources/views/patients/management/components/medical_certificate.blade.php
+++ b/resources/views/patients/management/components/medical_certificate.blade.php
@@ -1,4 +1,5 @@
-<div class="container-fluid">
+<!-- Management View (Default) -->
+<div id="management-view" class="container-fluid">
     <div class="card">
         <div class="card-header bg-warning text-dark">
             <h5 class="mb-0">
@@ -52,6 +53,462 @@
     </div>
 </div>
 
+<!-- Certificate Print View (Hidden by default) -->
+<div id="certificate-view" class="medical-certificate-container" style="display: none;">
+    <div class="certificate-page">
+        <!-- Header Section -->
+        <div class="certificate-header">
+            <div class="logo-section">
+                <div class="medical-logo">
+                    <div class="logo-circle">
+                        <i class="fas fa-cross"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="institution-info">
+                <h2 class="institution-name">DAVAO MEDICAL SCHOOL FOUNDATION</h2>
+                <h3 class="institution-location">DAVAO CITY</h3>
+                <h1 class="certificate-title">MEDICAL CERTIFICATE</h1>
+            </div>
+            <div class="date-section">
+                <div class="date-field">
+                    <span class="date-value" id="cert-date">{{ date('F j, Y') }}</span>
+                    <div class="underline"></div>
+                    <span class="field-label">Date</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Certificate Body -->
+        <div class="certificate-body">
+            <div class="salutation">
+                <strong>TO WHOM IT MAY CONCERN:</strong>
+            </div>
+
+            <div class="certification-text">
+                <p>This is to certify that
+                    <span class="field-value name-field " id="cert-patient-name">{{ $patient->first_name ?? '' }} {{ $patient->middle_name ?? '' }} {{ $patient->last_name ?? '' }}</span>,
+                    <span class="field-value short" id="cert-patient-age">{{ $patient->age ?? '' }}</span> years old
+                </p>
+                <p>of
+                    <span class="field-value long" id="cert-patient-address">{{ $patient->address ?? '' }}</span> has been treated/examined last
+                    <span class="field-value medium" id="cert-exam-date"></span>
+                </p>
+            </div>
+
+            <!-- Diagnosis Section -->
+            <div class="section-block">
+                <div class="section-header">
+                    <strong>DIAGNOSIS:</strong>
+                </div>
+                <div class="section-content">
+                    <div class="content-line">
+                        <span class="field-value full-width" id="cert-diagnosis"></span>
+                    </div>
+                    <div class="content-line">
+                        <span class="field-value full-width"></span>
+                    </div>
+                    <div class="content-line">
+                        <span class="field-value full-width"></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Remarks Section -->
+            <div class="section-block">
+                <div class="section-header">
+                    <strong>REMARKS:</strong>
+                </div>
+                <div class="section-content">
+                    <div class="content-line">
+                        <span class="field-value full-width" id="cert-remarks"></span>
+                    </div>
+                    <div class="content-line">
+                        <span class="field-value full-width"></span>
+                    </div>
+                    <div class="content-line">
+                        <span class="field-value full-width"></span>
+                    </div>
+                    <div class="content-line">
+                        <span class="field-value full-width"></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Physician Signature Section -->
+            <div class="signature-section">
+                <div class="signature-block">
+                    <div class="signature-line">
+                        <span class="field-value signature-field" id="cert-physician"></span>
+                    </div>
+                    <div class="signature-label">Physician</div>
+                </div>
+
+                <div class="credentials-block">
+                    <div class="credential-line">
+                        <span class="credential-label">License No.</span>
+                        <span class="field-value credential-field" id="cert-license"></span>
+                    </div>
+                    <div class="credential-line">
+                        <span class="credential-label">PTR No.</span>
+                        <span class="field-value credential-field" id="cert-ptr"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Print Controls -->
+    <div class="print-controls d-print-none mt-5 text-center">
+        <button type="button" class="btn btn-secondary me-2" onclick="showManagementView()">
+            <i class="fas fa-arrow-left me-1"></i>
+            Back to Management
+        </button>
+        <button type="button" class="btn btn-primary" onclick="window.print()">
+            <i class="fas fa-print me-1"></i>
+            Print Certificate
+        </button>
+    </div>
+</div>
+</div>
+<style>
+    .medical-certificate-container {
+        max-width: 8.5in;
+        margin: 0 auto;
+        background: white;
+        font-family: 'Times New Roman', serif;
+        color: #000;
+        line-height: 1.2;
+    }
+
+    .certificate-page {
+        padding: 0.5in;
+        min-height: 5.5in;
+        max-height: 5.5in;
+        background: white;
+        page-break-inside: avoid;
+        margin-bottom: 1rem;
+    }
+
+    /* Header Styles */
+    .certificate-header {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 1rem;
+        position: relative;
+    }
+
+    .logo-section {
+        flex: 0 0 80px;
+        margin-right: 15px;
+    }
+
+    .medical-logo .logo-circle {
+        width: 60px;
+        height: 60px;
+        border: 2px solid #000;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+    }
+
+    .institution-info {
+        flex: 1;
+        text-align: center;
+        margin-top: 5px;
+    }
+
+    .institution-name {
+        font-size: 14px;
+        font-weight: bold;
+        margin: 0;
+        letter-spacing: 0.5px;
+    }
+
+    .institution-location {
+        font-size: 12px;
+        font-weight: bold;
+        margin: 3px 0 10px 0;
+        letter-spacing: 0.3px;
+    }
+
+    .certificate-title {
+        font-size: 16px;
+        font-weight: bold;
+        margin: 0;
+        letter-spacing: 1px;
+    }
+
+    .date-section {
+        flex: 0 0 120px;
+        text-align: right;
+        margin-top: 10px;
+    }
+
+    .date-field {
+        text-align: center;
+    }
+
+    .date-value {
+        display: block;
+        margin-bottom: 5px;
+        font-size: 14px;
+    }
+
+    .underline {
+        height: 1px;
+        background: #000;
+        margin: 2px 0;
+    }
+
+    .field-label {
+        font-size: 12px;
+        margin-top: 5px;
+        display: block;
+    }
+
+    /* Body Styles */
+    .certificate-body {
+        margin-top: 1rem;
+        padding-left: 0;
+    }
+
+    .salutation {
+        margin-bottom: 1rem;
+        font-size: 12px;
+        text-align: left;
+        margin-left: 0;
+        padding-left: 0;
+    }
+
+    .certification-text {
+        margin-left: 0;
+        padding-left: 0;
+    }
+
+    .certification-text p {
+        margin: 0.5rem 0;
+        font-size: 12px;
+        text-indent: 0;
+        margin-left: 0;
+        text-align: left;
+        padding-left: 0;
+    }
+
+    .field-value {
+        font-weight: bold;
+        display: inline-block;
+        min-width: 80px;
+        border-bottom: 1px solid #000;
+        padding-bottom: 1px;
+        margin: 0 2px;
+    }
+
+    .field-value.short {
+        min-width: 55px;
+        width: 55px;
+        text-align: center;
+    }
+
+    .field-value.medium {
+        min-width: 115px;
+        width: 115px;
+        text-align: center;
+    }
+
+    .field-value.long {
+        min-width: 430px;
+        width: 430px;
+    }
+
+    .field-value.full-width {
+        min-width: 100%;
+        width: 100%;
+        margin: 0;
+    }
+
+    .field-value.name-field {
+        min-width: 50%;
+        width: 70%;
+        text-align: center;
+        margin: 0;
+    }
+
+    .field-value.signature-field {
+        min-width: 150px;
+        width: 150px;
+        text-align: center;
+        margin: 0 auto;
+    }
+
+    .field-value.credential-field {
+        min-width: 120px;
+        width: 120px;
+        margin: 0;
+    }
+
+    .underline-field {
+        display: inline-block;
+        border-bottom: 1px solid #000;
+        margin: 0 3px;
+        min-height: 16px;
+    }
+
+    .underline-field.short {
+        width: 40px;
+    }
+
+    .underline-field.medium {
+        width: 200px;
+    }
+
+    .underline-field.long {
+        width: 200px;
+    }
+
+    /* Section Styles */
+    .section-block {
+        margin: 1rem 0;
+    }
+
+    .section-header {
+        font-size: 12px;
+        margin-bottom: 0.3rem;
+        text-align: left;
+        margin-left: 0;
+    }
+
+    .section-content {
+        margin-left: 0;
+    }
+
+    .content-line {
+        margin: 0.5rem 0;
+        position: relative;
+        min-height: 15px;
+        display: block;
+    }
+
+    .content-underline {
+        border-bottom: 1px solid #000;
+        height: 15px;
+        width: 100%;
+    }
+
+    /* Signature Section */
+    .signature-section {
+        margin-top: 2rem;
+        margin-bottom: 4rem;
+        display: flex;
+        justify-content: flex-end;
+        align-items: flex-start;
+    }
+
+    .signature-block {
+        text-align: center;
+        margin-right: 1.5rem;
+    }
+
+    .signature-line {
+        margin-bottom: 0.3rem;
+        display: flex;
+        justify-content: center;
+    }
+
+    .signature-underline {
+        width: 150px;
+        height: 1px;
+        background: #000;
+        margin: 3px auto;
+    }
+
+    .signature-label {
+        font-size: 10px;
+        margin-top: 3px;
+    }
+
+    .credentials-block {
+        text-align: left;
+    }
+
+    .credential-line {
+        margin: 0.3rem 0;
+        display: flex;
+        align-items: center;
+    }
+
+    .credential-label {
+        font-size: 10px;
+        margin-right: 8px;
+        min-width: 60px;
+    }
+
+    .credential-underline {
+        flex: 1;
+        height: 1px;
+        background: #000;
+        margin-left: 8px;
+        max-width: 120px;
+    }
+
+    /* Certificate container padding for buttons */
+    .medical-certificate-container {
+        padding-bottom: 5rem;
+    }
+
+    /* Print controls positioning */
+    .print-controls {
+        margin-top: 3rem;
+        padding: 2rem 0;
+        /* background: rgba(248, 249, 250, 0.9); */
+        border-top: 1px solid #dee2e6;
+        position: relative;
+        z-index: 10;
+    }
+
+    /* Print Styles */
+    @media print {
+        .medical-certificate-container {
+            margin: 0;
+            max-width: none;
+            width: 8.5in;
+        }
+
+        .certificate-page {
+            padding: 0.3in;
+            margin: 0;
+            box-shadow: none;
+            height: 5.5in;
+            max-height: 5.5in;
+            overflow: hidden;
+        }
+
+        body {
+            background: white !important;
+        }
+
+        * {
+            -webkit-print-color-adjust: exact !important;
+            print-color-adjust: exact !important;
+        }
+
+        @page {
+            size: 8.5in 5.5in;
+            margin: 0;
+        }
+    }
+
+    /* Empty field styling for better visibility */
+    .field-value:empty::after {
+        content: "\00a0";
+        text-decoration: underline;
+        display: inline-block;
+        width: 80px;
+    }
+</style>
+
 <!-- Add Medical Certificate Modal -->
 <div class="modal fade" id="addCertificateModal" tabindex="-1" aria-labelledby="addCertificateModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
@@ -102,11 +559,11 @@
                         </div>
                     </div>
                     <div class="mb-3">
-                        <label for="medicalFindings" class="form-label">Medical Findings</label>
+                        <label for="medicalFindings" class="form-label">Medical Findings/Diagnosis</label>
                         <textarea class="form-control" id="medicalFindings" name="medical_findings" rows="3" placeholder="Brief medical assessment and findings"></textarea>
                     </div>
                     <div class="mb-3">
-                        <label for="recommendations" class="form-label">Recommendations/Restrictions</label>
+                        <label for="recommendations" class="form-label">Recommendations/Remarks</label>
                         <textarea class="form-control" id="recommendations" name="recommendations" rows="3" placeholder="Any work restrictions or recommendations"></textarea>
                     </div>
                     <div class="form-check">
@@ -267,7 +724,7 @@
         // Get action buttons
         function getActionButtons(cert) {
             let buttons = `
-            <button class="btn btn-sm btn-outline-primary view-pdf-btn" data-id="${cert.id}">View PDF</button>
+            <button class="btn btn-sm btn-outline-primary view-certificate-btn" data-cert='${JSON.stringify(cert)}'>View</button>
             <button class="btn btn-sm btn-outline-success download-pdf-btn" data-id="${cert.id}">Download</button>
         `;
 
@@ -288,10 +745,10 @@
             });
         }
 
-        // View PDF button click
-        $(document).on('click', '.view-pdf-btn', function() {
-            const certId = $(this).data('id');
-            window.open(`{{ url('/medical-certificates') }}/${certId}/pdf`, '_blank');
+        // View Certificate button click
+        $(document).on('click', '.view-certificate-btn', function() {
+            const cert = $(this).data('cert');
+            showCertificateView(cert);
         });
 
         // Download PDF button click
@@ -340,7 +797,47 @@
 
         // Preview certificate functionality
         $('#preview-certificate-btn').click(function() {
-            alert("Preview functionality will be implemented in future updates.");
+            const formData = new FormData($('#medical-certificate-form')[0]);
+            const cert = {
+                date_issued: formData.get('date_issued'),
+                medical_findings: formData.get('medical_findings'),
+                recommendations: formData.get('recommendations'),
+                issuing_doctor: formData.get('issuing_doctor'),
+                license_number: formData.get('license_number')
+            };
+            showCertificateView(cert, true);
         });
     });
+
+    // Function to show certificate view
+    function showCertificateView(cert, isPreview = false) {
+        // Populate certificate data
+        $('#cert-date').text(formatCertDate(cert.date_issued));
+        $('#cert-diagnosis').text(cert.medical_findings || '');
+        $('#cert-remarks').text(cert.recommendations || '');
+        $('#cert-physician').text(cert.issuing_doctor || '');
+        $('#cert-license').text(cert.license_number || '');
+        $('#cert-ptr').text(cert.ptr_number || '');
+        $('#cert-exam-date').text(cert.examination_date || formatCertDate(cert.date_issued));
+
+        // Hide management view and show certificate view
+        $('#management-view').hide();
+        $('#certificate-view').show();
+    }
+
+    // Function to show management view
+    function showManagementView() {
+        $('#certificate-view').hide();
+        $('#management-view').show();
+    }
+
+    // Format date for certificate
+    function formatCertDate(dateString) {
+        const date = new Date(dateString);
+        return date.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+        });
+    }
 </script>

--- a/resources/views/patients/management/components/medical_certificate.blade.php
+++ b/resources/views/patients/management/components/medical_certificate.blade.php
@@ -157,7 +157,7 @@
     </div>
 
     <!-- Print Controls -->
-    <div class="print-controls d-print-none mt-5 text-center">
+    <div class="print-controls d-print-none text-center">
         <button type="button" class="btn btn-secondary me-2" onclick="showManagementView()">
             <i class="fas fa-arrow-left me-1"></i>
             Back to Management
@@ -167,7 +167,6 @@
             Print Certificate
         </button>
     </div>
-</div>
 </div>
 <style>
     .medical-certificate-container {
@@ -183,10 +182,9 @@
     .certificate-page {
         padding: 0.5in;
         min-height: 5.5in;
-        max-height: 5.5in;
         background: white;
         page-break-inside: avoid;
-        margin-bottom: 1rem;
+        margin-bottom: 0;
     }
 
     /* Header Styles */
@@ -412,7 +410,7 @@
 
     /* Print controls positioning */
     .print-controls {
-        margin-top: 8rem !important;
+        margin-top: 1rem !important;
         padding: 3rem 0;
         border-top: 1px solid #dee2e6;
         clear: both;
@@ -420,23 +418,85 @@
 
     /* Print Styles */
     @media print {
+
+        /* Hide everything except the certificate */
+        body * {
+            visibility: hidden;
+        }
+
+        #certificate-view,
+        #certificate-view * {
+            visibility: visible;
+        }
+
+        #certificate-view {
+            position: fixed;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            page-break-after: avoid;
+            page-break-before: avoid;
+            page-break-inside: avoid;
+        }
+
         .medical-certificate-container {
             margin: 0;
             max-width: none;
-            width: 8.5in;
+            width: 100%;
+            padding-bottom: 0;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            page-break-after: avoid;
+            page-break-before: avoid;
+            page-break-inside: avoid;
         }
 
         .certificate-page {
-            padding: 0.3in;
+            padding: 0.5in;
             margin: 0;
             box-shadow: none;
-            height: 5.5in;
-            max-height: 5.5in;
-            overflow: hidden;
+            height: auto;
+            min-height: auto;
+            max-height: none;
+            width: 100%;
+            page-break-after: avoid;
+            page-break-before: avoid;
+            page-break-inside: avoid;
+        }
+
+        .certificate-header {
+            margin-bottom: 0.8rem;
+            page-break-after: avoid;
+        }
+
+        .certificate-body {
+            margin-top: 0.8rem;
+            page-break-inside: avoid;
+        }
+
+        .section-block {
+            margin: 0.8rem 0;
+            page-break-inside: avoid;
+        }
+
+        .signature-section {
+            margin-top: 1.5rem;
+            page-break-before: avoid;
         }
 
         body {
             background: white !important;
+            margin: 0 !important;
+            padding: 0 !important;
+        }
+
+        html,
+        body {
+            height: 100%;
+            overflow: hidden;
         }
 
         * {
@@ -445,7 +505,11 @@
         }
 
         @page {
-            size: 8.5in 5.5in;
+            size: 11in 8.5in;
+            margin: 0;
+        }
+
+        @page :first {
             margin: 0;
         }
     }

--- a/resources/views/patients/management/components/medical_certificate.blade.php
+++ b/resources/views/patients/management/components/medical_certificate.blade.php
@@ -87,7 +87,7 @@
 
             <div class="certification-text">
                 <p>This is to certify that
-                    <span class="field-value name-field " id="cert-patient-name">{{ $patient->first_name ?? '' }} {{ $patient->middle_name ?? '' }} {{ $patient->last_name ?? '' }}</span>,
+                    <span class="field-value name-field" id="cert-patient-name">{{ $patient->first_name ?? '' }} {{ $patient->middle_name ?? '' }} {{ $patient->last_name ?? '' }}</span>,
                     <span class="field-value short" id="cert-patient-age">{{ $patient->age ?? '' }}</span> years old
                 </p>
                 <p>of
@@ -272,29 +272,16 @@
     /* Body Styles */
     .certificate-body {
         margin-top: 1rem;
-        padding-left: 0;
     }
 
     .salutation {
         margin-bottom: 1rem;
         font-size: 12px;
-        text-align: left;
-        margin-left: 0;
-        padding-left: 0;
-    }
-
-    .certification-text {
-        margin-left: 0;
-        padding-left: 0;
     }
 
     .certification-text p {
         margin: 0.5rem 0;
         font-size: 12px;
-        text-indent: 0;
-        margin-left: 0;
-        text-align: left;
-        padding-left: 0;
     }
 
     .field-value {
@@ -307,8 +294,8 @@
     }
 
     .field-value.short {
-        min-width: 55px;
-        width: 55px;
+        min-width: 50px;
+        width: 50px;
         text-align: center;
     }
 
@@ -333,20 +320,17 @@
         min-width: 50%;
         width: 70%;
         text-align: center;
-        margin: 0;
     }
 
     .field-value.signature-field {
         min-width: 150px;
         width: 150px;
         text-align: center;
-        margin: 0 auto;
     }
 
     .field-value.credential-field {
         min-width: 120px;
         width: 120px;
-        margin: 0;
     }
 
     .underline-field {
@@ -354,18 +338,6 @@
         border-bottom: 1px solid #000;
         margin: 0 3px;
         min-height: 16px;
-    }
-
-    .underline-field.short {
-        width: 40px;
-    }
-
-    .underline-field.medium {
-        width: 200px;
-    }
-
-    .underline-field.long {
-        width: 200px;
     }
 
     /* Section Styles */
@@ -376,25 +348,11 @@
     .section-header {
         font-size: 12px;
         margin-bottom: 0.3rem;
-        text-align: left;
-        margin-left: 0;
-    }
-
-    .section-content {
-        margin-left: 0;
     }
 
     .content-line {
         margin: 0.5rem 0;
-        position: relative;
         min-height: 15px;
-        display: block;
-    }
-
-    .content-underline {
-        border-bottom: 1px solid #000;
-        height: 15px;
-        width: 100%;
     }
 
     /* Signature Section */
@@ -413,8 +371,6 @@
 
     .signature-line {
         margin-bottom: 0.3rem;
-        display: flex;
-        justify-content: center;
     }
 
     .signature-underline {
@@ -453,19 +409,11 @@
         max-width: 120px;
     }
 
-    /* Certificate container padding for buttons */
-    .medical-certificate-container {
-        padding-bottom: 5rem;
-    }
-
     /* Print controls positioning */
     .print-controls {
         margin-top: 3rem;
         padding: 2rem 0;
-        /* background: rgba(248, 249, 250, 0.9); */
         border-top: 1px solid #dee2e6;
-        position: relative;
-        z-index: 10;
     }
 
     /* Print Styles */

--- a/resources/views/patients/management/components/medical_certificate/print.blade.php
+++ b/resources/views/patients/management/components/medical_certificate/print.blade.php
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Medical Certificate</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            font-size: 14px;
+            line-height: 1.6;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+            border-bottom: 2px solid #333;
+            padding-bottom: 20px;
+        }
+
+        .hospital-name {
+            font-size: 24px;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+
+        .hospital-address {
+            font-size: 12px;
+            color: #666;
+        }
+
+        .certificate-title {
+            font-size: 20px;
+            font-weight: bold;
+            text-align: center;
+            margin: 30px 0;
+            text-decoration: underline;
+        }
+
+        .patient-info {
+            margin: 20px 0;
+        }
+
+        .info-row {
+            margin: 10px 0;
+        }
+
+        .label {
+            font-weight: bold;
+            display: inline-block;
+            width: 150px;
+        }
+
+        .content {
+            margin: 30px 0;
+            text-align: justify;
+        }
+
+        .findings {
+            margin: 20px 0;
+            padding: 15px;
+            background-color: #f9f9f9;
+            border-left: 4px solid #007bff;
+        }
+
+        .signature-section {
+            margin-top: 50px;
+            text-align: right;
+        }
+
+        .signature-line {
+            border-top: 1px solid #333;
+            width: 200px;
+            margin: 20px 0 5px auto;
+        }
+
+        .footer {
+            margin-top: 50px;
+            font-size: 10px;
+            color: #666;
+            text-align: center;
+        }
+
+        .certificate-number {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            font-size: 10px;
+            color: #666;
+        }
+
+        .status-stamp {
+            position: absolute;
+            top: 100px;
+            right: 50px;
+            transform: rotate(-15deg);
+            border: 3px solid #28a745;
+            color: #28a745;
+            padding: 10px 20px;
+            font-weight: bold;
+            font-size: 16px;
+        }
+
+        .revoked-stamp {
+            border-color: #dc3545;
+            color: #dc3545;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="certificate-number">
+        Certificate No: MC-{{ str_pad($certificate->id, 6, '0', STR_PAD_LEFT) }}
+    </div>
+
+    @if($certificate->status === 'active')
+    <div class="status-stamp">VALID</div>
+    @elseif($certificate->status === 'revoked')
+    <div class="status-stamp revoked-stamp">REVOKED</div>
+    @endif
+
+    <div class="header">
+        <div class="hospital-name">DAVAO MEDICAL SCHOOL FOUNDATION HOSPITAL</div>
+        <div class="hospital-address">
+            Gen. Malvar St., Davao City, Philippines<br>
+            Tel: (082) 226-4433 | Email: info@dmsf.edu.ph
+        </div>
+    </div>
+
+    <div class="certificate-title">MEDICAL CERTIFICATE</div>
+
+    <div class="patient-info">
+        <div class="info-row">
+            <span class="label">Patient Name:</span>
+            {{ $certificate->patient->first_name }} {{ $certificate->patient->middle_name }} {{ $certificate->patient->last_name }}
+        </div>
+        <div class="info-row">
+            <span class="label">Date of Birth:</span>
+            {{ $certificate->patient->birth_date ? \Carbon\Carbon::parse($certificate->patient->birth_date)->format('F d, Y') : 'N/A' }}
+        </div>
+        <div class="info-row">
+            <span class="label">Patient ID:</span>
+            {{ str_pad($certificate->patient->id, 6, '0', STR_PAD_LEFT) }}
+        </div>
+        <div class="info-row">
+            <span class="label">Certificate Type:</span>
+            {{ $certificate->certificate_type_display }}
+        </div>
+        <div class="info-row">
+            <span class="label">Date Issued:</span>
+            {{ $certificate->date_issued->format('F d, Y') }}
+        </div>
+        @if($certificate->valid_until)
+        <div class="info-row">
+            <span class="label">Valid Until:</span>
+            {{ $certificate->valid_until->format('F d, Y') }}
+        </div>
+        @endif
+    </div>
+
+    <div class="content">
+        <p><strong>TO WHOM IT MAY CONCERN:</strong></p>
+
+        <p>This is to certify that the above-named patient has been examined and found to be:</p>
+
+        <p><strong>Purpose:</strong> {{ $certificate->purpose }}</p>
+
+        @if($certificate->medical_findings)
+        <div class="findings">
+            <strong>Medical Findings:</strong><br>
+            {{ $certificate->medical_findings }}
+        </div>
+        @endif
+
+        @if($certificate->recommendations)
+        <div class="findings">
+            <strong>Recommendations/Restrictions:</strong><br>
+            {{ $certificate->recommendations }}
+        </div>
+        @endif
+
+        <p>This certification is issued upon request of the patient for {{ strtolower($certificate->purpose) }} purposes.</p>
+    </div>
+
+    <div class="signature-section">
+        <div style="margin-bottom: 50px;">
+            <div>{{ $certificate->issuing_doctor }}</div>
+            <div class="signature-line"></div>
+            <div>Attending Physician</div>
+            @if($certificate->license_number)
+            <div style="font-size: 12px;">License No: {{ $certificate->license_number }}</div>
+            @endif
+        </div>
+    </div>
+
+    @if($certificate->status === 'revoked')
+    <div style="margin-top: 30px; padding: 15px; background-color: #f8d7da; border: 1px solid #f5c6cb; color: #721c24;">
+        <strong>REVOCATION NOTICE:</strong><br>
+        This certificate has been revoked on {{ $certificate->revoked_at->format('F d, Y \a\t g:i A') }}.<br>
+        <strong>Reason:</strong> {{ $certificate->revocation_reason }}
+    </div>
+    @endif
+
+    <div class="footer">
+        <p>This is a computer-generated document. No signature is required.</p>
+        <p>Generated on {{ now()->format('F d, Y \a\t g:i A') }}</p>
+        @if($certificate->digital_signature)
+        <p><strong>Digitally Signed Certificate</strong></p>
+        @endif
+    </div>
+</body>
+
+</html>

--- a/resources/views/patients/management/components/medical_certificate_download_pdf.blade.php
+++ b/resources/views/patients/management/components/medical_certificate_download_pdf.blade.php
@@ -18,7 +18,7 @@
             line-height: 1.2;
             background: white;
             margin: 0;
-            padding: 0;
+            padding: 45px 0 0;
         }
 
         .medical-certificate-container {

--- a/resources/views/patients/management/components/medical_certificate_download_pdf.blade.php
+++ b/resources/views/patients/management/components/medical_certificate_download_pdf.blade.php
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Medical Certificate - {{ $certificate->id }}</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Times New Roman', serif;
+            color: #000;
+            line-height: 1.2;
+            background: white;
+            margin: 0;
+            padding: 0;
+        }
+
+        .medical-certificate-container {
+            width: 8.5in;
+            height: 5.5in;
+            margin: 0;
+            padding: 0;
+            background: white;
+        }
+
+        .certificate-page {
+            padding: 0.3in 0.5in;
+            height: 5.5in;
+            background: white;
+            overflow: hidden;
+        }
+
+        /* Header Styles */
+        .certificate-header {
+            display: table;
+            width: 100%;
+            margin-bottom: 0.5rem;
+        }
+
+        .logo-section {
+            display: table-cell;
+            width: 80px;
+            vertical-align: top;
+            padding-right: 15px;
+        }
+
+        .medical-logo .logo-circle {
+            width: 60px;
+            height: 60px;
+            border: 2px solid #000;
+            border-radius: 50%;
+            text-align: center;
+            line-height: 56px;
+            font-size: 18px;
+        }
+
+        .institution-info {
+            display: table-cell;
+            text-align: center;
+            vertical-align: top;
+            padding-top: 5px;
+        }
+
+        .institution-name {
+            font-size: 14px;
+            font-weight: bold;
+            margin: 0;
+            letter-spacing: 0.5px;
+        }
+
+        .institution-location {
+            font-size: 12px;
+            font-weight: bold;
+            margin: 3px 0 10px 0;
+            letter-spacing: 0.3px;
+        }
+
+        .certificate-title {
+            font-size: 16px;
+            font-weight: bold;
+            margin: 0;
+            letter-spacing: 1px;
+        }
+
+        .date-section {
+            display: table-cell;
+            width: 120px;
+            text-align: center;
+            vertical-align: top;
+            padding-top: 10px;
+        }
+
+        .date-value {
+            display: block;
+            margin-bottom: 5px;
+            font-size: 14px;
+        }
+
+        .underline {
+            height: 1px;
+            background: #000;
+            margin: 2px 0;
+        }
+
+        .field-label {
+            font-size: 12px;
+            margin-top: 5px;
+            display: block;
+        }
+
+        /* Body Styles */
+        .certificate-body {
+            margin-top: 0.5rem;
+        }
+
+        .salutation {
+            margin-bottom: 0.5rem;
+            font-size: 12px;
+        }
+
+        .certification-text p {
+            margin: 0.5rem 0;
+            font-size: 12px;
+        }
+
+        .field-value {
+            font-weight: bold;
+            display: inline-block;
+            min-width: 80px;
+            border-bottom: 1px solid #000;
+            padding-bottom: 1px;
+            margin: 0 2px;
+        }
+
+        .field-value.short {
+            min-width: 50px;
+            width: 50px;
+            text-align: center;
+        }
+
+        .field-value.medium {
+            min-width: 115px;
+            width: 115px;
+            text-align: center;
+        }
+
+        .field-value.long {
+            min-width: 430px;
+            width: 430px;
+        }
+
+        .field-value.full-width {
+            min-width: 100%;
+            width: 100%;
+            margin: 0;
+        }
+
+        .field-value.name-field {
+            min-width: 50%;
+            width: 70%;
+            text-align: center;
+        }
+
+        .field-value.signature-field {
+            min-width: 150px;
+            width: 150px;
+            text-align: center;
+        }
+
+        .field-value.credential-field {
+            min-width: 120px;
+            width: 120px;
+        }
+
+        /* Section Styles */
+        .section-block {
+            margin: 0.5rem 0;
+        }
+
+        .section-header {
+            font-size: 12px;
+            margin-bottom: 0.2rem;
+        }
+
+        .content-line {
+            margin: 0.3rem 0;
+            min-height: 15px;
+        }
+
+        /* Signature Section */
+        .signature-section {
+            margin-top: 1rem;
+            margin-bottom: 0.5rem;
+            text-align: right;
+        }
+
+        .signature-block {
+            display: inline-block;
+            text-align: center;
+            margin-right: 1.5rem;
+            vertical-align: top;
+        }
+
+        .signature-line {
+            margin-bottom: 0.3rem;
+        }
+
+        .signature-label {
+            font-size: 10px;
+            margin-top: 3px;
+        }
+
+        .credentials-block {
+            display: inline-block;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .credential-line {
+            margin: 0.3rem 0;
+        }
+
+        .credential-label {
+            font-size: 10px;
+            margin-right: 8px;
+            display: inline-block;
+            min-width: 60px;
+        }
+
+        @page {
+            size: 8.5in 5.5in landscape;
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="medical-certificate-container">
+        <div class="certificate-page">
+            <!-- Header Section -->
+            <div class="certificate-header">
+                <div class="logo-section">
+                    <div class="medical-logo">
+                        <div class="logo-circle">
+                            +
+                        </div>
+                    </div>
+                </div>
+                <div class="institution-info">
+                    <h2 class="institution-name">DAVAO MEDICAL SCHOOL FOUNDATION</h2>
+                    <h3 class="institution-location">DAVAO CITY</h3>
+                    <h1 class="certificate-title">MEDICAL CERTIFICATE</h1>
+                </div>
+                <div class="date-section">
+                    <div class="date-field">
+                        <span class="date-value">{{ \Carbon\Carbon::parse($certificate->date_issued)->format('F j, Y') }}</span>
+                        <div class="underline"></div>
+                        <span class="field-label">Date</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Certificate Body -->
+            <div class="certificate-body">
+                <div class="salutation">
+                    <strong>TO WHOM IT MAY CONCERN:</strong>
+                </div>
+
+                <div class="certification-text">
+                    <p>This is to certify that
+                        <span class="field-value name-field">{{ $patient->first_name }} {{ $patient->middle_name }} {{ $patient->last_name }}</span>,
+                        <span class="field-value short">{{ $patient->age ?? '' }}</span> years old
+                    </p>
+                    <p>of
+                        <span class="field-value long">{{ $patient->address ?? '' }}</span> has been treated/examined last
+                        <span class="field-value medium">{{ \Carbon\Carbon::parse($certificate->date_issued)->format('F j, Y') }}</span>
+                    </p>
+                </div>
+
+                <!-- Diagnosis Section -->
+                <div class="section-block">
+                    <div class="section-header">
+                        <strong>DIAGNOSIS:</strong>
+                    </div>
+                    <div class="section-content">
+                        <div class="content-line">
+                            <span class="field-value full-width">{{ $certificate->medical_findings ?? '' }}</span>
+                        </div>
+                        <div class="content-line">
+                            <span class="field-value full-width">&nbsp;</span>
+                        </div>
+                        <div class="content-line">
+                            <span class="field-value full-width">&nbsp;</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Remarks Section -->
+                <div class="section-block">
+                    <div class="section-header">
+                        <strong>REMARKS:</strong>
+                    </div>
+                    <div class="section-content">
+                        <div class="content-line">
+                            <span class="field-value full-width">{{ $certificate->recommendations ?? '' }}</span>
+                        </div>
+                        <div class="content-line">
+                            <span class="field-value full-width">&nbsp;</span>
+                        </div>
+                        <div class="content-line">
+                            <span class="field-value full-width">&nbsp;</span>
+                        </div>
+                        <div class="content-line">
+                            <span class="field-value full-width">&nbsp;</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Physician Signature Section -->
+                <div class="signature-section">
+                    <div class="signature-block">
+                        <div class="signature-line">
+                            <span class="field-value signature-field">{{ $certificate->issuing_doctor }}</span>
+                        </div>
+                        <div class="signature-label">Physician</div>
+                    </div>
+
+                    <div class="credentials-block">
+                        <div class="credential-line">
+                            <span class="credential-label">License No.</span>
+                            <span class="field-value credential-field">{{ $certificate->license_number ?? '' }}</span>
+                        </div>
+                        <div class="credential-line">
+                            <span class="credential-label">PTR No.</span>
+                            <span class="field-value credential-field">&nbsp;</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/patients/management/components/medical_certificate_download_pdf.blade.php
+++ b/resources/views/patients/management/components/medical_certificate_download_pdf.blade.php
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +23,7 @@
 
         .medical-certificate-container {
             width: 8.5in;
-            height: 5.5in;
+            height: 7.5in;
             margin: 0;
             padding: 0;
             background: white;
@@ -30,7 +31,7 @@
 
         .certificate-page {
             padding: 0.3in 0.5in;
-            height: 5.5in;
+            height: 7.5in;
             background: white;
             overflow: hidden;
         }
@@ -49,14 +50,15 @@
             padding-right: 15px;
         }
 
-        .medical-logo .logo-circle {
+        .medical-logo {
             width: 60px;
             height: 60px;
-            border: 2px solid #000;
-            border-radius: 50%;
-            text-align: center;
-            line-height: 56px;
-            font-size: 18px;
+        }
+
+        .medical-logo img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
         }
 
         .institution-info {
@@ -233,21 +235,20 @@
         }
 
         @page {
-            size: 8.5in 5.5in landscape;
+            size: 8.5in 7.5in landscape;
             margin: 0;
         }
     </style>
 </head>
+
 <body>
     <div class="medical-certificate-container">
         <div class="certificate-page">
             <!-- Header Section -->
             <div class="certificate-header">
                 <div class="logo-section">
-                    <div class="medical-logo">
-                        <div class="logo-circle">
-                            +
-                        </div>
+                    <div class="medical-logo" style="margin-left: 20px; width:100px; height:100px; margin-bottom:20px;">
+                        <img src="{{ public_path('images/dmsf_logo_transparent.png') }}" alt="DMSF Logo">
                     </div>
                 </div>
                 <div class="institution-info">
@@ -344,4 +345,5 @@
         </div>
     </div>
 </body>
+
 </html>

--- a/resources/views/patients/management/components/referral_form.blade.php
+++ b/resources/views/patients/management/components/referral_form.blade.php
@@ -15,9 +15,9 @@
                     </button>
                 </div>
             </div>
-            
+
             <div class="table-responsive">
-                <table class="table table-striped table-hover">
+                <table class="table table-striped table-hover" id="referral-forms-table">
                     <thead class="table-dark">
                         <tr>
                             <th>Date</th>
@@ -29,54 +29,20 @@
                             <th>Actions</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <tr>
-                            <td>{{ date('Y-m-d') }}</td>
-                            <td>Dr. Maria Santos</td>
-                            <td>Endocrinology</td>
-                            <td><span class="badge bg-warning">Routine</span></td>
-                            <td>Diabetes management consultation</td>
-                            <td><span class="badge bg-primary">Pending</span></td>
-                            <td>
-                                <button class="btn btn-sm btn-outline-primary">View</button>
-                                <button class="btn btn-sm btn-outline-success">Print</button>
-                                <button class="btn btn-sm btn-outline-info">Track</button>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="7" class="text-center text-muted">
-                                <em>No additional referrals found. Click "Create Referral" to get started.</em>
-                            </td>
-                        </tr>
+                    <tbody id="referrals-tbody">
+                        <!-- Dynamic content will be loaded here -->
                     </tbody>
                 </table>
             </div>
-            
+
             <div class="row mt-4">
                 <div class="col-md-6">
                     <div class="card border-primary">
                         <div class="card-header bg-primary text-white">
                             <h6 class="mb-0"><i class="fas fa-hospital me-1"></i> Common Referral Destinations</h6>
                         </div>
-                        <div class="card-body">
-                            <ul class="list-group list-group-flush">
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    Endocrinology
-                                    <span class="badge bg-primary rounded-pill">3</span>
-                                </li>
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    Cardiology
-                                    <span class="badge bg-primary rounded-pill">2</span>
-                                </li>
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    Ophthalmology
-                                    <span class="badge bg-primary rounded-pill">1</span>
-                                </li>
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    Nephrology
-                                    <span class="badge bg-primary rounded-pill">1</span>
-                                </li>
-                            </ul>
+                        <div class="card-body" id="specialties-stats">
+                            <!-- Dynamic specialty statistics will be loaded here -->
                         </div>
                     </div>
                 </div>
@@ -85,24 +51,8 @@
                         <div class="card-header bg-info text-white">
                             <h6 class="mb-0"><i class="fas fa-chart-pie me-1"></i> Referral Status Overview</h6>
                         </div>
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between align-items-center mb-2">
-                                <span>Pending</span>
-                                <span class="badge bg-warning">4</span>
-                            </div>
-                            <div class="d-flex justify-content-between align-items-center mb-2">
-                                <span>Completed</span>
-                                <span class="badge bg-success">12</span>
-                            </div>
-                            <div class="d-flex justify-content-between align-items-center mb-2">
-                                <span>Cancelled</span>
-                                <span class="badge bg-danger">1</span>
-                            </div>
-                            <hr>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <strong>Total Referrals</strong>
-                                <strong><span class="badge bg-primary">17</span></strong>
-                            </div>
+                        <div class="card-body" id="status-stats">
+                            <!-- Dynamic status statistics will be loaded here -->
                         </div>
                     </div>
                 </div>
@@ -120,15 +70,17 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <form>
+                <form id="referral-form">
+                    @csrf
+                    <input type="hidden" name="patient_id" value="{{ $patient->id }}">
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="referralDate" class="form-label">Referral Date</label>
-                            <input type="date" class="form-control" id="referralDate" value="{{ date('Y-m-d') }}">
+                            <input type="date" class="form-control" id="referralDate" name="referral_date" value="{{ date('Y-m-d') }}" required>
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="priority" class="form-label">Priority</label>
-                            <select class="form-select" id="priority">
+                            <select class="form-select" id="priority" name="priority" required>
                                 <option value="routine">Routine</option>
                                 <option value="urgent">Urgent</option>
                                 <option value="emergency">Emergency</option>
@@ -138,7 +90,7 @@
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="specialty" class="form-label">Specialty</label>
-                            <select class="form-select" id="specialty">
+                            <select class="form-select" id="specialty" name="specialty" required>
                                 <option value="">Select specialty</option>
                                 <option value="endocrinology">Endocrinology</option>
                                 <option value="cardiology">Cardiology</option>
@@ -147,38 +99,49 @@
                                 <option value="neurology">Neurology</option>
                                 <option value="orthopedics">Orthopedics</option>
                                 <option value="dermatology">Dermatology</option>
+                                <option value="psychiatry">Psychiatry</option>
+                                <option value="pulmonology">Pulmonology</option>
+                                <option value="gastroenterology">Gastroenterology</option>
+                                <option value="oncology">Oncology</option>
+                                <option value="urology">Urology</option>
                                 <option value="other">Other</option>
                             </select>
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="referredDoctor" class="form-label">Referred To (Doctor/Clinic)</label>
-                            <input type="text" class="form-control" id="referredDoctor" placeholder="Dr. Name or Clinic Name">
+                            <input type="text" class="form-control" id="referredDoctor" name="referred_doctor" placeholder="Dr. Name or Clinic Name" required>
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="institution" class="form-label">Institution/Hospital</label>
-                            <input type="text" class="form-control" id="institution" placeholder="Hospital or clinic name">
+                            <input type="text" class="form-control" id="institution" name="institution" placeholder="Hospital or clinic name">
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="contactInfo" class="form-label">Contact Information</label>
-                            <input type="text" class="form-control" id="contactInfo" placeholder="Phone number or email">
+                            <input type="text" class="form-control" id="contactInfo" name="contact_info" placeholder="Phone number or email">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="referringDoctor" class="form-label">Referring Doctor</label>
+                            <input type="text" class="form-control" id="referringDoctor" name="referring_doctor" placeholder="Your name as referring physician">
                         </div>
                     </div>
                     <div class="mb-3">
                         <label for="reasonForReferral" class="form-label">Reason for Referral</label>
-                        <textarea class="form-control" id="reasonForReferral" rows="3" placeholder="Detailed reason for referral, including current symptoms and concerns"></textarea>
+                        <textarea class="form-control" id="reasonForReferral" name="reason_for_referral" rows="3" placeholder="Detailed reason for referral, including current symptoms and concerns" required></textarea>
                     </div>
                     <div class="mb-3">
                         <label for="relevantHistory" class="form-label">Relevant Medical History</label>
-                        <textarea class="form-control" id="relevantHistory" rows="3" placeholder="Relevant past medical history, current medications, and investigations"></textarea>
+                        <textarea class="form-control" id="relevantHistory" name="relevant_history" rows="3" placeholder="Relevant past medical history, current medications, and investigations"></textarea>
                     </div>
                     <div class="mb-3">
                         <label for="urgencyReason" class="form-label">Urgency/Timeline</label>
-                        <textarea class="form-control" id="urgencyReason" rows="2" placeholder="If urgent, explain why immediate attention is needed"></textarea>
+                        <textarea class="form-control" id="urgencyReason" name="urgency_reason" rows="2" placeholder="If urgent, explain why immediate attention is needed"></textarea>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="includeReports">
+                        <input class="form-check-input" type="checkbox" id="includeReports" name="include_reports" value="1">
                         <label class="form-check-label" for="includeReports">
                             Include recent test results and imaging reports
                         </label>
@@ -187,9 +150,320 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-outline-primary">Preview</button>
-                <button type="button" class="btn btn-primary">Create Referral</button>
+                <button type="button" class="btn btn-outline-primary" id="preview-referral-btn">Preview</button>
+                <button type="button" class="btn btn-primary" id="create-referral-btn">Create Referral</button>
             </div>
         </div>
     </div>
-</div> 
+</div>
+
+<!-- Track Referral Modal -->
+<div class="modal fade" id="trackReferralModal" tabindex="-1" aria-labelledby="trackReferralModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="trackReferralModalLabel">Track Referral Progress</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="tracking-form">
+                    @csrf
+                    <input type="hidden" id="track-referral-id" name="referral_id">
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="trackingStatus" class="form-label">Current Status</label>
+                            <select class="form-select" id="trackingStatus" name="status" required>
+                                <option value="pending">Pending</option>
+                                <option value="in_progress">In Progress</option>
+                                <option value="completed">Completed</option>
+                                <option value="cancelled">Cancelled</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="appointmentDate" class="form-label">Appointment Date</label>
+                            <input type="date" class="form-control" id="appointmentDate" name="appointment_date">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="trackingNotes" class="form-label">Tracking Notes</label>
+                        <textarea class="form-control" id="trackingNotes" name="tracking_notes" rows="3" placeholder="Update on referral progress, appointment details, etc."></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="outcome" class="form-label">Outcome (if completed)</label>
+                        <textarea class="form-control" id="outcome" name="outcome" rows="3" placeholder="Final outcome, recommendations, follow-up required, etc."></textarea>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="update-tracking-btn">Update Tracking</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function() {
+        // Load referrals and statistics on page load
+        loadReferralForms();
+        loadReferralStatistics();
+
+        // Create referral form submission
+        $('#create-referral-btn').click(function() {
+            const form = $('#referral-form')[0];
+            const formData = new FormData(form);
+
+            $.ajax({
+                url: "{{ route('referral-forms.store') }}",
+                method: "POST",
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: function(response) {
+                    if (response.success) {
+                        alert("Referral form created successfully!");
+                        $('#addReferralModal').modal('hide');
+                        $('#referral-form')[0].reset();
+                        loadReferralForms();
+                        loadReferralStatistics();
+                    }
+                },
+                error: function(xhr) {
+                    let errorMessage = "An error occurred. Please try again.";
+                    if (xhr.responseJSON && xhr.responseJSON.errors) {
+                        const errors = xhr.responseJSON.errors;
+                        errorMessage = Object.values(errors).flat().join('\n');
+                    }
+                    alert(errorMessage);
+                }
+            });
+        });
+
+        // Load referral forms
+        function loadReferralForms() {
+            $.ajax({
+                url: "{{ route('patients.referral-forms', $patient->id) }}",
+                method: "GET",
+                success: function(response) {
+                    const tbody = $('#referrals-tbody');
+                    tbody.empty();
+
+                    if (response.referrals.length === 0) {
+                        tbody.append(`
+                        <tr>
+                            <td colspan="7" class="text-center text-muted">
+                                <em>No referrals found. Click "Create Referral" to get started.</em>
+                            </td>
+                        </tr>
+                    `);
+                    } else {
+                        response.referrals.forEach(function(referral) {
+                            const priorityBadge = getPriorityBadge(referral.priority);
+                            const statusBadge = getStatusBadge(referral.status);
+                            const actions = getActionButtons(referral);
+
+                            tbody.append(`
+                            <tr>
+                                <td>${formatDate(referral.referral_date)}</td>
+                                <td>${referral.referred_doctor}</td>
+                                <td>${getSpecialtyDisplay(referral.specialty)}</td>
+                                <td><span class="badge ${priorityBadge}">${getPriorityDisplay(referral.priority)}</span></td>
+                                <td>${truncateText(referral.reason_for_referral, 50)}</td>
+                                <td><span class="badge ${statusBadge}">${getStatusDisplay(referral.status)}</span></td>
+                                <td>${actions}</td>
+                            </tr>
+                        `);
+                        });
+                    }
+                },
+                error: function(xhr) {
+                    console.error("Error loading referral forms:", xhr);
+                    alert("Error loading referral forms. Please refresh the page.");
+                }
+            });
+        }
+
+        // Load referral statistics
+        function loadReferralStatistics() {
+            $.ajax({
+                url: "{{ route('patients.referral-statistics', $patient->id) }}",
+                method: "GET",
+                success: function(response) {
+                    // Update status statistics
+                    const statusStats = $('#status-stats');
+                    statusStats.html(`
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span>Pending</span>
+                        <span class="badge bg-warning">${response.statistics.pending}</span>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span>In Progress</span>
+                        <span class="badge bg-info">${response.statistics.in_progress}</span>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span>Completed</span>
+                        <span class="badge bg-success">${response.statistics.completed}</span>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span>Cancelled</span>
+                        <span class="badge bg-danger">${response.statistics.cancelled}</span>
+                    </div>
+                    <hr>
+                    <div class="d-flex justify-content-between align-items-center">
+                        <strong>Total Referrals</strong>
+                        <strong><span class="badge bg-primary">${response.statistics.total}</span></strong>
+                    </div>
+                `);
+
+                    // Update specialty statistics
+                    const specialtyStats = $('#specialties-stats');
+                    if (response.specialties.length > 0) {
+                        let specialtyHtml = '<ul class="list-group list-group-flush">';
+                        response.specialties.forEach(function(specialty) {
+                            specialtyHtml += `
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                ${getSpecialtyDisplay(specialty.specialty)}
+                                <span class="badge bg-primary rounded-pill">${specialty.count}</span>
+                            </li>
+                        `;
+                        });
+                        specialtyHtml += '</ul>';
+                        specialtyStats.html(specialtyHtml);
+                    } else {
+                        specialtyStats.html('<p class="text-muted">No referrals yet</p>');
+                    }
+                },
+                error: function(xhr) {
+                    console.error("Error loading referral statistics:", xhr);
+                }
+            });
+        }
+
+        // Helper functions
+        function getPriorityBadge(priority) {
+            switch (priority) {
+                case 'routine':
+                    return 'bg-success';
+                case 'urgent':
+                    return 'bg-warning';
+                case 'emergency':
+                    return 'bg-danger';
+                default:
+                    return 'bg-secondary';
+            }
+        }
+
+        function getStatusBadge(status) {
+            switch (status) {
+                case 'pending':
+                    return 'bg-warning';
+                case 'in_progress':
+                    return 'bg-info';
+                case 'completed':
+                    return 'bg-success';
+                case 'cancelled':
+                    return 'bg-danger';
+                default:
+                    return 'bg-secondary';
+            }
+        }
+
+        function getPriorityDisplay(priority) {
+            return priority.charAt(0).toUpperCase() + priority.slice(1);
+        }
+
+        function getStatusDisplay(status) {
+            return status === 'in_progress' ? 'In Progress' : status.charAt(0).toUpperCase() + status.slice(1);
+        }
+
+        function getSpecialtyDisplay(specialty) {
+            return specialty.charAt(0).toUpperCase() + specialty.slice(1);
+        }
+
+        function getActionButtons(referral) {
+            return `
+            <button class="btn btn-sm btn-outline-primary view-referral-btn" data-id="${referral.id}">View</button>
+            <button class="btn btn-sm btn-outline-success print-referral-btn" data-id="${referral.id}">Print</button>
+            <button class="btn btn-sm btn-outline-info track-referral-btn" data-id="${referral.id}">Track</button>
+        `;
+        }
+
+        function formatDate(dateString) {
+            const date = new Date(dateString);
+            return date.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+            });
+        }
+
+        function truncateText(text, maxLength) {
+            return text.length > maxLength ? text.substring(0, maxLength) + '...' : text;
+        }
+
+        // Action button handlers
+        $(document).on('click', '.view-referral-btn', function() {
+            const referralId = $(this).data('id');
+            window.open(`{{ url('/referral-forms') }}/${referralId}/print`, '_blank');
+        });
+
+        $(document).on('click', '.print-referral-btn', function() {
+            const referralId = $(this).data('id');
+            window.location.href = `{{ url('/referral-forms') }}/${referralId}/download`;
+        });
+
+        $(document).on('click', '.track-referral-btn', function() {
+            const referralId = $(this).data('id');
+            $('#track-referral-id').val(referralId);
+
+            // Load current referral data
+            $.ajax({
+                url: `{{ url('/referral-forms') }}/${referralId}`,
+                method: "GET",
+                success: function(response) {
+                    const referral = response.referral;
+                    $('#trackingStatus').val(referral.status);
+                    $('#appointmentDate').val(referral.appointment_date);
+                    $('#trackingNotes').val(referral.tracking_notes || '');
+                    $('#outcome').val(referral.outcome || '');
+                    $('#trackReferralModal').modal('show');
+                }
+            });
+        });
+
+        // Update tracking form submission
+        $('#update-tracking-btn').click(function() {
+            const referralId = $('#track-referral-id').val();
+            const formData = {
+                _token: "{{ csrf_token() }}",
+                status: $('#trackingStatus').val(),
+                appointment_date: $('#appointmentDate').val(),
+                tracking_notes: $('#trackingNotes').val(),
+                outcome: $('#outcome').val()
+            };
+
+            $.ajax({
+                url: `{{ url('/referral-forms') }}/${referralId}/tracking`,
+                method: "PUT",
+                data: formData,
+                success: function(response) {
+                    if (response.success) {
+                        alert("Tracking information updated successfully!");
+                        $('#trackReferralModal').modal('hide');
+                        loadReferralForms();
+                        loadReferralStatistics();
+                    }
+                },
+                error: function(xhr) {
+                    alert("An error occurred while updating tracking information. Please try again.");
+                }
+            });
+        });
+
+        // Preview referral functionality
+        $('#preview-referral-btn').click(function() {
+            alert("Preview functionality will be implemented in future updates.");
+        });
+    });
+</script>

--- a/resources/views/patients/management/components/referral_form/print.blade.php
+++ b/resources/views/patients/management/components/referral_form/print.blade.php
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Medical Referral Form</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            font-size: 14px;
+            line-height: 1.6;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+            border-bottom: 2px solid #333;
+            padding-bottom: 20px;
+        }
+
+        .hospital-name {
+            font-size: 24px;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+
+        .hospital-address {
+            font-size: 12px;
+            color: #666;
+        }
+
+        .form-title {
+            font-size: 20px;
+            font-weight: bold;
+            text-align: center;
+            margin: 30px 0;
+            text-decoration: underline;
+        }
+
+        .section {
+            margin: 20px 0;
+        }
+
+        .section-title {
+            font-weight: bold;
+            font-size: 16px;
+            margin-bottom: 10px;
+            color: #333;
+            border-bottom: 1px solid #ccc;
+            padding-bottom: 5px;
+        }
+
+        .info-row {
+            margin: 8px 0;
+            display: flex;
+        }
+
+        .label {
+            font-weight: bold;
+            display: inline-block;
+            width: 200px;
+            vertical-align: top;
+        }
+
+        .value {
+            flex: 1;
+        }
+
+        .priority-urgent {
+            color: #dc3545;
+            font-weight: bold;
+        }
+
+        .priority-emergency {
+            color: #6f42c1;
+            font-weight: bold;
+        }
+
+        .priority-routine {
+            color: #28a745;
+        }
+
+        .text-content {
+            margin: 15px 0;
+            padding: 10px;
+            background-color: #f8f9fa;
+            border-left: 4px solid #007bff;
+        }
+
+        .footer {
+            margin-top: 50px;
+            font-size: 10px;
+            color: #666;
+            text-align: center;
+        }
+
+        .referral-number {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            font-size: 10px;
+            color: #666;
+        }
+
+        .signature-section {
+            margin-top: 40px;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .signature-box {
+            text-align: center;
+            width: 45%;
+        }
+
+        .signature-line {
+            border-top: 1px solid #333;
+            margin: 30px 0 5px 0;
+        }
+
+        .checkbox {
+            width: 15px;
+            height: 15px;
+            border: 1px solid #333;
+            display: inline-block;
+            margin-right: 5px;
+            vertical-align: middle;
+        }
+
+        .checkbox.checked::after {
+            content: "✓";
+            font-weight: bold;
+            font-size: 12px;
+            line-height: 13px;
+            text-align: center;
+            display: block;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="referral-number">
+        Referral No: RF-{{ str_pad($referral->id, 6, '0', STR_PAD_LEFT) }}
+    </div>
+
+    <div class="header">
+        <div class="hospital-name">DAVAO MEDICAL SCHOOL FOUNDATION HOSPITAL</div>
+        <div class="hospital-address">
+            Gen. Malvar St., Davao City, Philippines<br>
+            Tel: (082) 226-4433 | Email: info@dmsf.edu.ph
+        </div>
+    </div>
+
+    <div class="form-title">MEDICAL REFERRAL FORM</div>
+
+    <div class="section">
+        <div class="section-title">PATIENT INFORMATION</div>
+        <div class="info-row">
+            <span class="label">Patient Name:</span>
+            <span class="value">{{ $referral->patient->first_name }} {{ $referral->patient->middle_name }} {{ $referral->patient->last_name }}</span>
+        </div>
+        <div class="info-row">
+            <span class="label">Date of Birth:</span>
+            <span class="value">{{ $referral->patient->birth_date ? \Carbon\Carbon::parse($referral->patient->birth_date)->format('F d, Y') : 'N/A' }}</span>
+        </div>
+        <div class="info-row">
+            <span class="label">Patient ID:</span>
+            <span class="value">{{ str_pad($referral->patient->id, 6, '0', STR_PAD_LEFT) }}</span>
+        </div>
+        <div class="info-row">
+            <span class="label">Gender:</span>
+            <span class="value">{{ $referral->patient->gender ?? 'N/A' }}</span>
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="section-title">REFERRAL DETAILS</div>
+        <div class="info-row">
+            <span class="label">Referral Date:</span>
+            <span class="value">{{ $referral->referral_date->format('F d, Y') }}</span>
+        </div>
+        <div class="info-row">
+            <span class="label">Priority:</span>
+            <span class="value priority-{{ $referral->priority }}">{{ $referral->priority_display }}</span>
+        </div>
+        <div class="info-row">
+            <span class="label">Specialty:</span>
+            <span class="value">{{ $referral->specialty_display }}</span>
+        </div>
+        <div class="info-row">
+            <span class="label">Referred To:</span>
+            <span class="value">{{ $referral->referred_doctor }}</span>
+        </div>
+        @if($referral->institution)
+        <div class="info-row">
+            <span class="label">Institution:</span>
+            <span class="value">{{ $referral->institution }}</span>
+        </div>
+        @endif
+        @if($referral->contact_info)
+        <div class="info-row">
+            <span class="label">Contact Information:</span>
+            <span class="value">{{ $referral->contact_info }}</span>
+        </div>
+        @endif
+        @if($referral->referring_doctor)
+        <div class="info-row">
+            <span class="label">Referring Doctor:</span>
+            <span class="value">{{ $referral->referring_doctor }}</span>
+        </div>
+        @endif
+    </div>
+
+    <div class="section">
+        <div class="section-title">CLINICAL INFORMATION</div>
+
+        <div style="margin-bottom: 15px;">
+            <strong>Reason for Referral:</strong>
+            <div class="text-content">
+                {{ $referral->reason_for_referral }}
+            </div>
+        </div>
+
+        @if($referral->relevant_history)
+        <div style="margin-bottom: 15px;">
+            <strong>Relevant Medical History:</strong>
+            <div class="text-content">
+                {{ $referral->relevant_history }}
+            </div>
+        </div>
+        @endif
+
+        @if($referral->urgency_reason)
+        <div style="margin-bottom: 15px;">
+            <strong>Urgency/Timeline:</strong>
+            <div class="text-content">
+                {{ $referral->urgency_reason }}
+            </div>
+        </div>
+        @endif
+
+        <div style="margin-top: 20px;">
+            <div class="checkbox {{ $referral->include_reports ? 'checked' : '' }}"></div>
+            <strong>Include recent test results and imaging reports</strong>
+        </div>
+    </div>
+
+    @if($referral->tracking_notes || $referral->appointment_date || $referral->outcome)
+    <div class="section">
+        <div class="section-title">TRACKING INFORMATION</div>
+
+        <div class="info-row">
+            <span class="label">Current Status:</span>
+            <span class="value">{{ $referral->status_display }}</span>
+        </div>
+
+        @if($referral->appointment_date)
+        <div class="info-row">
+            <span class="label">Appointment Date:</span>
+            <span class="value">{{ $referral->appointment_date->format('F d, Y') }}</span>
+        </div>
+        @endif
+
+        @if($referral->tracking_notes)
+        <div style="margin-bottom: 15px;">
+            <strong>Tracking Notes:</strong>
+            <div class="text-content">
+                {{ $referral->tracking_notes }}
+            </div>
+        </div>
+        @endif
+
+        @if($referral->outcome)
+        <div style="margin-bottom: 15px;">
+            <strong>Outcome:</strong>
+            <div class="text-content">
+                {{ $referral->outcome }}
+            </div>
+        </div>
+        @endif
+    </div>
+    @endif
+
+    <div class="signature-section">
+        <div class="signature-box">
+            <div>Referring Physician</div>
+            <div class="signature-line"></div>
+            <div>{{ $referral->referring_doctor ?? 'Name and Signature' }}</div>
+            <div style="font-size: 12px; margin-top: 5px;">Date: {{ $referral->referral_date->format('F d, Y') }}</div>
+        </div>
+
+        <div class="signature-box">
+            <div>Receiving Physician</div>
+            <div class="signature-line"></div>
+            <div>{{ $referral->referred_doctor }}</div>
+            <div style="font-size: 12px; margin-top: 5px;">Date: _________________</div>
+        </div>
+    </div>
+
+    <div class="footer">
+        <p>This is a computer-generated referral form.</p>
+        <p>Generated on {{ now()->format('F d, Y \a\t g:i A') }}</p>
+        <p><strong>IMPORTANT:</strong> Please bring this referral form and any relevant medical records to your appointment.</p>
+    </div>
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\SubstanceScreenerRecommendationController as SubstanceR
 use App\Http\Controllers\MedicineController;
 use App\Http\Controllers\MedicalCertificateController;
 use App\Http\Controllers\PrescriptionController;
+use App\Http\Controllers\ReferralFormController;
 use App\Http\Controllers\PhysicalActivityController;
 use App\Http\Controllers\InformedConsentController;
 use App\Http\Controllers\ResearchEligibilityController;
@@ -313,6 +314,16 @@ Route::middleware('auth')->group(function () {
     Route::get('/medical-certificates/{id}/download', [MedicalCertificateController::class, 'downloadPdf'])->name('medical-certificates.download');
     Route::put('/medical-certificates/{id}', [MedicalCertificateController::class, 'update'])->name('medical-certificates.update');
     Route::put('/medical-certificates/{id}/revoke', [MedicalCertificateController::class, 'revoke'])->name('medical-certificates.revoke');
+
+    // Referral form routes
+    Route::post('/referral-forms', [ReferralFormController::class, 'store'])->name('referral-forms.store');
+    Route::get('/patients/{patient}/referral-forms', [ReferralFormController::class, 'getByPatient'])->name('patients.referral-forms');
+    Route::get('/patients/{patient}/referral-statistics', [ReferralFormController::class, 'getStatistics'])->name('patients.referral-statistics');
+    Route::get('/referral-forms/{id}', [ReferralFormController::class, 'show'])->name('referral-forms.show');
+    Route::get('/referral-forms/{id}/print', [ReferralFormController::class, 'printPdf'])->name('referral-forms.print');
+    Route::get('/referral-forms/{id}/download', [ReferralFormController::class, 'downloadPdf'])->name('referral-forms.download');
+    Route::put('/referral-forms/{id}', [ReferralFormController::class, 'update'])->name('referral-forms.update');
+    Route::put('/referral-forms/{id}/tracking', [ReferralFormController::class, 'updateTracking'])->name('referral-forms.tracking');
 
 
     // Debug route

--- a/routes/web.php
+++ b/routes/web.php
@@ -317,6 +317,7 @@ Route::middleware('auth')->group(function () {
 
     // Referral form routes
     Route::post('/referral-forms', [ReferralFormController::class, 'store'])->name('referral-forms.store');
+    Route::post('/referral-forms/preview', [ReferralFormController::class, 'preview'])->name('referral-forms.preview');
     Route::get('/patients/{patient}/referral-forms', [ReferralFormController::class, 'getByPatient'])->name('patients.referral-forms');
     Route::get('/patients/{patient}/referral-statistics', [ReferralFormController::class, 'getStatistics'])->name('patients.referral-statistics');
     Route::get('/referral-forms/{id}', [ReferralFormController::class, 'show'])->name('referral-forms.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PatientController;
@@ -24,6 +25,7 @@ use App\Http\Controllers\CAGE4AssessmentController as CAGE4;
 use App\Http\Controllers\ASSIST8AssessmentController as ASSIST8;
 use App\Http\Controllers\SubstanceScreenerRecommendationController as SubstanceRecs;
 use App\Http\Controllers\MedicineController;
+use App\Http\Controllers\MedicalCertificateController;
 use App\Http\Controllers\PrescriptionController;
 use App\Http\Controllers\PhysicalActivityController;
 use App\Http\Controllers\InformedConsentController;
@@ -92,7 +94,6 @@ Route::middleware(['auth', 'role:bhw_s3|bhw_s4|bhw_s5|bhw_s6|admin|doctor'])->gr
     Route::post('/patients/{patient}/update-measurement-date', [PatientController::class, 'updateMeasurementDate'])->name('patients.update-measurement-date');
     Route::get('/patients/{patient}/measurements/{tabNumber}/{date?}', [PatientController::class, 'getMeasurementsForTab'])->name('patients.get-measurements-for-tab');
     Route::get('/patients/{patient}/measurements/{tab}', [PatientController::class, 'getMeasurementsForTab'])->name('patients.get-measurements');
-
 });
 
 Route::middleware(['auth', 'role:bhw_s4|bhw_s5|bhw_s6|admin|doctor'])->group(function () {
@@ -102,14 +103,13 @@ Route::middleware(['auth', 'role:bhw_s4|bhw_s5|bhw_s6|admin|doctor'])->group(fun
     Route::get('/research-eligibility/check/{patientId}', [ResearchEligibilityController::class, 'check'])->name('research_eligibility.check');
     Route::post('/first-encounter-screening/store', [ResearchEligibilityController::class, 'storeFirstEncounter'])->name('first-encounter-screening.store');
 
-    
+
     // Exclusion Criteria Routes
     Route::post('/research-exclusion/store', [\App\Http\Controllers\ResearchExclusionController::class, 'store'])->name('research_exclusion.store');
     Route::get('/research-exclusion/check/{patientId}', [\App\Http\Controllers\ResearchExclusionController::class, 'check'])->name('research_exclusion.check');
     Route::get('/patients/{patient}/comprehensive-history', [ComprehensiveHistoryController::class, 'show'])->name('comprehensive-history.show');
     Route::get('/patients/{patient}/comprehensive-history/data', [ComprehensiveHistoryController::class, 'get'])->name('comprehensive-history.get');
     Route::post('/patients/{patient}/comprehensive-history', [ComprehensiveHistoryController::class, 'store'])->name('comprehensive-history.store');
-
 });
 
 
@@ -124,13 +124,13 @@ Route::middleware(['auth', 'role:bhw_s5|bhw_s6|admin|doctor'])->group(function (
     Route::get('/consultations/{consultation}/nutrition', [NutritionController::class, 'getByConsultation'])->name('nutrition.by-consultation');
     Route::get('/consultations/{consultation}/quality-of-life', [QualityOfLifeController::class, 'getByConsultation'])->name('quality-of-life.by-consultation');
     Route::get('/consultations/{consultation}/telemedicine-perception', [TelemedicinePerceptionController::class, 'getByConsultation'])->name('telemedicine-perception.by-consultation');
-    Route::get('/consultations/{consultation}/physical-activity', [PhysicalActivityController::class, 'getByConsultation'])->name('physical-activity.by-consultation');    
+    Route::get('/consultations/{consultation}/physical-activity', [PhysicalActivityController::class, 'getByConsultation'])->name('physical-activity.by-consultation');
     Route::post('/physical-activity', [PhysicalActivityController::class, 'store'])->name('physical-activity.store');
     Route::get('/physical-activity/{id}', [PhysicalActivityController::class, 'show'])->name('physical-activity.show');
     Route::get('/physical-activity', [PhysicalActivityController::class, 'get_lists'])->name('physical-activity.get_lists');
-    
+
     // Tab-specific measurement routes
-    
+
     Route::get('/patient/{patient_id}/macronutrients', [PatientController::class, 'getMacronutrients']);
     Route::post('/patients/{id}/blood-sugar', [BloodSugarController::class, 'store'])->name('blood-sugar.store');
     Route::get('/patients/{id}/blood-sugar', [BloodSugarController::class, 'index'])->name('patients.blood-sugar.index');
@@ -147,7 +147,7 @@ Route::middleware(['auth', 'role:bhw_s5|bhw_s6|admin|doctor'])->group(function (
     Route::post('/save-meal-plan', [MealPlanController::class, 'store'])->name('save-meal-plan');
     Route::post('/qualityoflife/store', [QualityOfLifeController::class, 'store'])->name('qualityoflife.store');
     Route::get('/qualityoflife/{patient_id}', [QualityOfLifeController::class, 'index'])->name('qualityoflife.index');
-	
+
     // Physical Examination Routes
     Route::post('/patients/{patient}/general-survey', [PhysicalExaminationController::class, 'storeGeneralSurvey'])->name('physical-examination.general-survey');
     Route::post('/patients/{patient}/skin-hair', [PhysicalExaminationController::class, 'storeSkinHair'])->name('physical-examination.skin-hair');
@@ -166,7 +166,7 @@ Route::middleware(['auth', 'role:bhw_s5|bhw_s6|admin|doctor'])->group(function (
     Route::post('/patients/{patient}/extremities', [PhysicalExaminationController::class, 'storeExtremities'])->name('physical-examination.extremities');
     Route::post('/patients/{patient}/nervous-system', [PhysicalExaminationController::class, 'storeNervousSystem'])->name('physical-examination.nervous-system');
 
-    
+
     // New social connectedness per-assessment routes
     Route::post('/social-initial-assessments', [SocialInitial::class, 'store'])->name('social-initial-assessments.store');
     Route::get('/social-initial-assessments/{patientId}', [SocialInitial::class, 'show'])->name('social-initial-assessments.show');
@@ -205,34 +205,34 @@ Route::middleware(['auth', 'role:bhw_s5|bhw_s6|admin|doctor'])->group(function (
 
     // Get all physical examination data
     Route::get('/patients/{patient}/physical-examination', [PhysicalExaminationController::class, 'getAll'])->name('physical-examination.get-all');
-    
+
     Route::resource('sleep-screenings', SleepScreeningController::class);
-    
+
     // Sleep Initial Assessment routes
     Route::post('/sleep-initial-assessments', [SleepInitialAssessmentController::class, 'store'])->name('sleep-initial-assessments.store');
     Route::get('/sleep-initial-assessments/{patientId}', [SleepInitialAssessmentController::class, 'show'])->name('sleep-initial-assessments.show');
     Route::put('/sleep-initial-assessments/{id}', [SleepInitialAssessmentController::class, 'update'])->name('sleep-initial-assessments.update');
-    
+
     // ISI-7 Assessment routes
     Route::post('/isi7-assessments', [ISI7AssessmentController::class, 'store'])->name('isi7-assessments.store');
     Route::get('/isi7-assessments/{patientId}', [ISI7AssessmentController::class, 'show'])->name('isi7-assessments.show');
     Route::put('/isi7-assessments/{id}', [ISI7AssessmentController::class, 'update'])->name('isi7-assessments.update');
-    
+
     // ESS-8 Assessment routes
     Route::post('/ess8-assessments', [ESS8AssessmentController::class, 'store'])->name('ess8-assessments.store');
     Route::get('/ess8-assessments/{patientId}', [ESS8AssessmentController::class, 'show'])->name('ess8-assessments.show');
     Route::put('/ess8-assessments/{id}', [ESS8AssessmentController::class, 'update'])->name('ess8-assessments.update');
-    
+
     // SHI-13 Assessment routes
     Route::post('/shi13-assessments', [SHI13AssessmentController::class, 'store'])->name('shi13-assessments.store');
     Route::get('/shi13-assessments/{patientId}', [SHI13AssessmentController::class, 'show'])->name('shi13-assessments.show');
     Route::put('/shi13-assessments/{id}', [SHI13AssessmentController::class, 'update'])->name('shi13-assessments.update');
-    
+
     // STOP-BANG Assessment routes
     Route::post('/stopbang-assessments', [STOPBANGAssessmentController::class, 'store'])->name('stopbang-assessments.store');
     Route::get('/stopbang-assessments/{patientId}', [STOPBANGAssessmentController::class, 'show'])->name('stopbang-assessments.show');
     Route::put('/stopbang-assessments/{id}', [STOPBANGAssessmentController::class, 'update'])->name('stopbang-assessments.update');
-    
+
     // Legacy sleep-assessments route for backward compatibility
     Route::post('/sleep-assessments', [SleepScreeningController::class, 'store'])->name('sleep-assessments.store');
 
@@ -254,13 +254,12 @@ Route::middleware(['auth', 'role:bhw_s5|bhw_s6|admin|doctor'])->group(function (
     Route::get('/patients/{patient}/comprehensive-history/attachments/{attachment}', [ComprehensiveHistoryAttachmentController::class, 'show'])->name('comprehensive-history-attachments.show');
     Route::delete('/patients/{patient}/comprehensive-history/attachments/{attachment}', [ComprehensiveHistoryAttachmentController::class, 'destroy'])->name('comprehensive-history-attachments.destroy');
     Route::get('/patients/{patient}/comprehensive-history/attachments/{attachment}/download', [ComprehensiveHistoryAttachmentController::class, 'download'])->name('comprehensive-history-attachments.download');
-
 });
 
 Route::middleware('auth')->group(function () {
     // Check if informed consent have already been submitted
     Route::get('/informed-consent/check/{patientId}', [InformedConsentController::class, 'checkConsentSubmitted'])->name('informed_consent.check');
-    
+
     // Profile routes
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
@@ -290,7 +289,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/social-connectedness', [SocialConnectednessController::class, 'store'])->name('submit.socialConnectedness');
     Route::get('/social-connectedness/{patient_id}', [SocialConnectednessController::class, 'show'])->name('get.socialConnectedness');
     Route::get('/social-connectedness/{patient_id}/data', [SocialConnectednessController::class, 'getDataByPatient'])->name('socialConnectedness.getDataByPatient');
-    
+
     // Substance use recommendations (backend computed)
     Route::post('/substance-recommendations', [SubstanceRecs::class, 'recommend'])->name('substance.recommendations');
     Route::get('/medicines/search', [MedicineController::class, 'getMedicines'])->name('medicines.search');
@@ -306,9 +305,18 @@ Route::middleware('auth')->group(function () {
     Route::put('/lifestyle-prescriptions/{lifestylePrescription}', [LifestylePrescriptionController::class, 'update'])->name('lifestyle-prescriptions.update');
     Route::delete('/lifestyle-prescriptions/{lifestylePrescription}', [LifestylePrescriptionController::class, 'destroy'])->name('lifestyle-prescriptions.destroy');
 
+    // Medical certificate routes
+    Route::post('/medical-certificates', [MedicalCertificateController::class, 'store'])->name('medical-certificates.store');
+    Route::get('/patients/{patient}/medical-certificates', [MedicalCertificateController::class, 'getByPatient'])->name('patients.medical-certificates');
+    Route::get('/medical-certificates/{id}', [MedicalCertificateController::class, 'show'])->name('medical-certificates.show');
+    Route::get('/medical-certificates/{id}/pdf', [MedicalCertificateController::class, 'viewPdf'])->name('medical-certificates.pdf');
+    Route::get('/medical-certificates/{id}/download', [MedicalCertificateController::class, 'downloadPdf'])->name('medical-certificates.download');
+    Route::put('/medical-certificates/{id}', [MedicalCertificateController::class, 'update'])->name('medical-certificates.update');
+    Route::put('/medical-certificates/{id}/revoke', [MedicalCertificateController::class, 'revoke'])->name('medical-certificates.revoke');
+
 
     // Debug route
-    Route::get('/debug/comprehensive-history/{patient}', function(App\Models\Patient $patient) {
+    Route::get('/debug/comprehensive-history/{patient}', function (App\Models\Patient $patient) {
         $comprehensiveHistory = $patient->comprehensiveHistory()->first();
         return [
             'patient_id' => $patient->id,
@@ -328,5 +336,4 @@ Route::middleware('auth')->group(function () {
     });
 });
 
-require __DIR__.'/auth.php';
-
+require __DIR__ . '/auth.php';


### PR DESCRIPTION

Adds a dedicated print view and a PDF template (landscape) for the medical certificate. Binds dynamic patient data and cleans up layout/styles (margins, padding, logo image, container dimensions) to prevent clipping and improve readability.

# What Changed

* Print view (HTML/CSS/JS) with dynamic data
* PDF template + generation set to **landscape**
* Uses the correct template in PDF view
* Layout fixes: margins, padding, container/page size
* Replaced logo placeholder with image
* Tidy/refactor of styles

# How to Test

1. Open the medical-certificate print route/view with a real record.
2. Check on-screen layout (headers, logo, no overflow).
3. Print preview → confirm **Landscape** and no clipping.
4. Generate PDF → data is complete and layout matches preview.
5. Try long names/notes and missing optional fields.

# Acceptance Criteria

* [ ] Print view renders correctly with full patient data
* [ ] PDF uses the correct template in **landscape**
* [ ] No clipping/overflow; long text wraps
* [ ] Styles scoped to the certificate (no regressions)

#  Checklist

* [ ] Correct template wired for print/PDF
* [ ] Orientation & paper size as expected (A4/Letter)
* [ ] All patient fields map correctly; nulls handled
* [ ] Logo loads cleanly; no layout shift if missing
* [ ] Print CSS scoped (doesn’t affect other pages)
* [ ] Chrome print preview and generated PDF look the same
